### PR TITLE
cleaning up introduction and removing content that goes off track

### DIFF
--- a/ten-simple-rules-dockerfiles.Rmd
+++ b/ten-simple-rules-dockerfiles.Rmd
@@ -337,7 +337,7 @@ You can view all labels with [`docker inspect`](https://docs.docker.com/engine/r
 Labels serve as structured metadata that can be leveraged by services, e.g., https://microbadger.com/labels.
 For example, software versions, license, and maintainer contact information are commonly seen and very useful if a `Dockerfile` is discovered out of context.
 While you can add arbitrarily complex information with labels, for research compendia the user-facing documentation is much more important.
-Important metadata that might be more utilized with future tools includes global identifiers such as [ORCID identifiers](https://orcid.org/), DOIs of the research compendium, e.g., [reserved on Zenodo](https://help.zenodo.org/), or a funding agency's grant number.
+Important metadata that might be more utilized with future tools includes global identifiers such as [ORCID identifiers](https://orcid.org/), DOIs of the research compendium (cf. [https://research-compendium.science](https://research-compendium.science)), e.g., [reserved on Zenodo](https://help.zenodo.org/), or a funding agency's grant number.
 
 The OCI Image Format Specification provides some common label keys (see the "Annotations" section in @opencontainers_image-spec_2017) to help standardise field names across container tools, as shown below.
 These labels match the [`org.label-schema`-specification](http://label-schema.org/rc1/), which has been deprecated but is still found a lot in `Dockerfile`s.

--- a/ten-simple-rules-dockerfiles.Rmd
+++ b/ten-simple-rules-dockerfiles.Rmd
@@ -290,7 +290,7 @@ Generally, aim to design the `RUN` instructions so that each performs one scoped
 Each instruction will result in a new layer, and reasonably grouped changes increase readability of the `Dockerfile` and facilitate inspection of the image, e.g., with tools like dive [@goodman_dive_2019].
 Convoluted `RUN` instructions can be acceptable to reduce the number of layers, but careful layout and consistent formatting should be applied (see \ruleref{rule:formatting}).
 
-While you will find `Dockerfile`s using [_build-time variables_](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) to dynamically change parameters at build time, such a customization option reduces clarity for data science workflows based on research compendia.
+While you will find `Dockerfile`s using [_build-time variables_](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) to dynamically change parameters at build time, such a customization option reduces clarity for data science workflows.
 
 # 4. Document within the Dockerfile
 \rulelabel{3}{rule:document}
@@ -336,8 +336,8 @@ The [`LABEL` instruction](https://docs.docker.com/engine/reference/builder/#labe
 You can view all labels with [`docker inspect`](https://docs.docker.com/engine/reference/commandline/inspect/) command.
 Labels serve as structured metadata that can be leveraged by services, e.g., https://microbadger.com/labels.
 For example, software versions, license, and maintainer contact information are commonly seen and very useful if a `Dockerfile` is discovered out of context.
-While you can add arbitrarily complex information with labels, for research compendia the user-facing documentation is much more important.
-Important metadata that might be more utilized with future tools includes global identifiers such as [ORCID identifiers](https://orcid.org/), DOIs of the research compendium (cf. [https://research-compendium.science](https://research-compendium.science)), e.g., [reserved on Zenodo](https://help.zenodo.org/), or a funding agency's grant number.
+While you can add arbitrarily complex information with labels, for data science scenarios the user-facing documentation is much more important.
+Relevant metadata that might be more utilized with future tools includes global identifiers such as [ORCID identifiers](https://orcid.org/), DOIs of the research compendium (cf. [https://research-compendium.science](https://research-compendium.science)), e.g., [reserved on Zenodo](https://help.zenodo.org/), or a funding agency's grant number.
 
 The OCI Image Format Specification provides some common label keys (see the "Annotations" section in @opencontainers_image-spec_2017) to help standardise field names across container tools, as shown below.
 These labels match the [`org.label-schema`-specification](http://label-schema.org/rc1/), which has been deprecated but is still found a lot in `Dockerfile`s.
@@ -612,7 +612,7 @@ Furthermore, the commit messages in your version controlled repository preserve 
 While there are exceptions to the rule (cf.&nbsp;@kim_bio-docklets_2017), it's generally a simple and clear approach to provide one `Dockerfile` per project.
 Alternatively, you could build an _image stack_ to serve different use cases with a common base image, but this reduces understandability and scatters information across multiple places.
 We recommend to avoid this at the price of a longer `Dockerfile` and mitigate with consistent form (see&nbsp;\ruleref{rule:formatting}).
-Importantly, you should publish _all_ files `COPY`ied into the container, e.g., test data or files for software installation from source (see&nbsp;\ruleref{rule:mount}), in the same research compendium.
+Importantly, you should publish _all_ files `COPY`ied into the container, e.g., test data or files for software installation from source (see&nbsp;\ruleref{rule:mount}) in the same public repository as the `Dockerfile`, e.g., in a research compendium.
 
 It is likely going to be the case that over time you will develop workflows that are similar in nature to one another.
 When developing or working on projects with containers you can switch between isolated project environments by stopping the container and restarting it when you are ready to work again, even on another machine or in a cloud environment.

--- a/ten-simple-rules-dockerfiles.Rmd
+++ b/ten-simple-rules-dockerfiles.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Ten Simple Rules for Writing Dockerfiles for Reproducible Research"
+title: "Ten Simple Rules for Writing Dockerfiles for Reproducible Data Science"
 author:
   - name: Daniel Nüst
     # https://github.com/nuest
@@ -61,22 +61,17 @@ Submission notes:
 
 Computing infrastructure has advanced to the point where not only can we share data underlying resarch articles, we can share the
 code that processes these data.
-The sharing of code files is enabled by collaboration platforms such as [GitHub](https://github.com) or [GitLab](https://gitlab.com) and has become quite common.
-The sharing of the computing environment is enabled by containerisation, but this possibility is not widely used yet.
-Containerisation allows for documenting and sharing entire workflows in a comprehensive way, which is desperately needed to increase reproducibility of computational resarch.
-Computational research is oftentimes way too complicated for "papers" based on the traditional journal article format to fully communicate the details of research [@marwick_how_2015], but where the actual contribution to knowledge includes the full computing environment that produced a result [@donoho_invitation_2010].
+This sharing of code files is enabled by collaboration platforms such as [GitHub](https://github.com) or [GitLab](https://gitlab.com) and has become quite common.
+The sharing of the computing environment, on the other hand, is enabled by containerization, which allows for documenting and sharing entire workflows in a comprehensive way.
+This sharing of computational assets is paramount to increase reproducibility of computational resarch.
+While "papers" based on the traditional journal article format can share high level details of research, computational research is oftentimes way too complicated to be disseminated alongside in this format [@marwick_how_2015]. 
+In that the actual contribution to knowledge includes the full computing environment that produced a result, containerization is needed [@donoho_invitation_2010].
 
-A solution for packaging the building blocks of computer-based research, i.e. code, data, documentation, and the computing environment, is the _research compendium_ (cf. [https://research-compendium.science](https://research-compendium.science)).
-A research compendium greatly improves the transparancy and reproducibility of our research, because we not only publish abstract algorithms and study designs, but also the instructions for recreating and executing whole research workflows.
-Within a research compendium, it is desirable to include instructions, i.e. a human- _and_ machine-readable recipe, for building containers that capture the computing environment.
-The computing environment comprises all software and data dependencies, as these are not captured by the the typical workflow script or documentation in a README.
+Containerization plays an important role in providing instructions for packaging the building blocks of computer-based research (i.e. code, data, documentation, and the computing environment). While a container cannot package all of these blocks, it represents a human- _and_ machine-readable recipe to capture the computing environment and interact with data.
 By providing this recipe, authors of scientific articles greatly improve their work's level of documentation, transparency, and reusability.
 Such practice is one important part of common practices for scientific computing [@wilson_best_2014; @wilson_good_2017], with the result that it is much more likely both the author and others are able to reproduce and extend an analysis workflow.
 The containers built from these recipes are portable encapsulated snapshots of a specific computing environment.
 Such containers have been demonstrated for capturing scientific notebooks [@rule_ten_2019] and reproducible workflows [@sandve_ten_2013].
-Research compendia also allow for proper citation of the used computing environment, which is not possible within containers alone.
-Best practices are still a work in progress [cf. @katz_software_2018], but you should try your best to give credit to creators of software you rely on by following recommendations of projects such as CodeMeta ([https://codemeta.github.io/](https://codemeta.github.io/)) and the Citation File Format ([https://citation-file-format.github.io/](https://citation-file-format.github.io/)).
-<!-- https://github.com/force11/force11-sciwg/issues/55 -->
 
 While there are several tutorials for using containers for reproducible research [@nust_author_2017; @chapman_reproducible_2018; @ropensci_labs_r_2015; @udemy_docker_2019; @psomopoulos_lesson_2017], there is no detailed _manual for how to write the actual instructions to create the containers for computational research_ besides generic best practices [@docker_inc_best_2020].
 This article introduces these instructions for the popular `Dockerfile` format with a focus on containers encapsulating data science workflows.
@@ -84,31 +79,23 @@ This article introduces these instructions for the popular `Dockerfile` format w
 # Prerequisites & scope
 
 To start with, we assume you have a scripted scientific workflow, i.e. you can, at least at a certain point in time, execute the full process with a fixed set of commands, for example `make prepare_data` followed by `Rscript analysis.R`, or only `python3 my-workflow.py`.
-If you have an ordered set of commands building upon each other, you can write a main script that does just that, even if you in your daily work might not do that to save time.
-A key constraint is that containers you eventually share with others as part of a research compendium can only run open source software.
-Therefore tools like Mathematica and Matlab are out of scope of this work.
-This execution should be able to be triggered by command-line instruction, which is possible for all generic programming languages and widely used workflow tools, including tools primarily used interactively and/or with a graphical user interface.
-<!--, but may also be opening and starting a process with a graphical user interface.-->
-A workflow that does not support scripted execution is out of scope for reproducible research, and does not fit well with containerisation.
+Since containers that you eventually share with others can only run open source software, tools like Mathematica and Matlab are out of scope for this example. A workflow that does not support scripted execution is also out of scope for reproducible research, as it does not fit well with containerization. Furthermore, workflows interacting with many petabytes of data and executed in high-performance computing (HPC) infrastructures are out of scope. Using such HPC job managers or cloud infrastructures would require a collection of "Ten Simple Rules" articles in their own right.
+For this article, we focus on workflows that typically run on single machine, e.g., a researchers laptop computer or a virtual server.
+The reader might scope the data requirement to less than a terabyte, and compute requirement to a machine with 16 cores running over the weekend.
 
-Furthermore, workflows interacting with many petabytes of data and executed in high-performance computing (HPC) infrastructures are out of scope.
-While containers _can_ be helpful for analysing data at scale, the complexity of theses pipelines, e.g., using HPC job managers or cloud infrastructures, requires a collection of "Ten Simple Rules" articles in their own right.
-Instead, we focus on workflows that typically run on single machine, e.g., a researchers laptop computer or a virtual server, though they may take some time and resources to execute, such as a terabyte of data and 16 cores running over the weekend.
-
-In the case of more complex applications that require multiple applications, e.g., web servers, databases, and worker containers, it might be better to have a _set of containers_ using `docker-compose` [@docker-compose_2019].
+While out of scope for this article, we point the reader to `docker-compose` [@docker-compose_2019] in the case of needing container orchestration for multiple applications, e.g., web servers, databases, and worker containers. 
 A `docker-compose.yml` configuration file allows for defining volumes, environment variables, and exposed ports and helps to stick to  _one purpose per container_, which often means one process running in the container, and to combine existing stable building blocks instead of bespoke massive containers for specific purposes.
-Using `docker-compose` for a data science workflow is out of scope for this article.
 
 Because _"the number of unique research environments approximates the number of researchers"_ [@nust_opening_2017], sticking to conventions helps every researcher to understand, modify, and eventually write container recipes suitable for their needs.
-Even if they are not sure how the technology behind them actually works, reserachers can leverage containerisation, but should craft their own definition of computing environments following good practices, which are provided here.
-These practices are strongly related to software engineering in general and research software engineering (RSEng) in particlar, which is concerned with quality, training, and recognition of software in science [@cohen_four_2020].
+Even if they are not sure how the technology behind them actually works, researchers should leverage containerization following good practices.
+The practices that are to be discussed in this article are strongly related to software engineering in general and research software engineering (RSEng) in particlar, which is concerned with quality, training, and recognition of software in science [@cohen_four_2020].
 Research Software Engineers (RSEs) are not the target audience for this work, but we want to encourage you to reach out to your local or national RSE community if your needs go beyond the rules of this work.
 
 While there are many different container technologies, this article focuses on Docker [@wikipedia_contributors_docker_2019].
 Docker is a highly suitable tool for reproducible research (e.g., @boettiger_introduction_2017) and our observations indicate it is the most widely used container technology in academic data science.
 The goal of this article is to guide you to write a `Dockerfile`, which is a file format for creating container images.
 The rules help you to ensure the `Dockerfile` allows for interactive development as well as the higher goals of reproducibility and preservation of knowledge.
-Such practices are generally not part of generic containerisation tutorials and are rarely found in `Dockerfile`s published as part of software projects, which are often used as templates by novices.
+Such practices are generally not part of generic containerization tutorials and are rarely found in `Dockerfile`s published as part of software projects, which are often used as templates by novices.
 The differences between a helpful, stable `Dockerfile` and one that is misleading, prone to failure, and full of potential obstacles, are not obvious, especially for researchers who do not have extensive software development experience or formal training.
 A commitment to this article's rules can ensure that workflows are reproducible and reusable, that computing environments are understandable by others, and researchers can collaborate effectively.
 Their application should not be triggered by the publication of a finished project, but be weaved into day-to-day habits (cf. thoughts on openness as an afterthought by @chen_open_2019 and on computational reproducibility by @donoho_invitation_2010).
@@ -121,12 +108,12 @@ Several platforms for facilitating reproducible research are built on top of con
 
 To create Docker containers for specific workflows, we write text files that follow a particular format called `Dockerfile` [@docker_inc_dockerfile_2019]. 
 `Dockerfile`s are machine- and human-readable recipes for building images.
-Images are inert, immutable, read-only files that include the application, e.g., the programming language interpreter needed to run a workflow, and the system libraries required by an application to run.
+Container images include the application, e.g., the programming language interpreter needed to run a workflow, and the system libraries required by an application to run.
 A `Dockerfile` consists of a sequence of instructions to copy files and install software.
-Each instructions adds a layers to the image, which can be cached across image builds and platforms for minimizing build and download times.
-The images have a main executable that is started when they are run as stateful containers, which are the running instances of Docker images.
+Each instruction adds a layer to the image, which can be cached across image builds and platforms for minimizing build and download times.
+The images have a main executable exposed as an "entrypoint" that is started when they are run as stateful containers, which are the running instances of Docker images.
 Containers can be modified, stopped, restarted and purged.
-`Dockerfiles`, like Makefiles [@wikipedia_contributors_make_2019], are meant to be useful for both humans to read and for computers to execute.
+`Dockerfile`s, like Makefiles [@wikipedia_contributors_make_2019], are meant to be useful for both humans to read and for computers to execute.
 See Listing&nbsp;1 for a full `Dockerfile`, which we will refer to throughout this article.
 
 While Docker was the original technology to support the `Dockerfile` format, other container technologies with support include [podman](https://podman.io/)/[buildah](https://github.com/containers/buildah) supported by RedHat, [kaniko](https://github.com/GoogleContainerTools/kaniko), [img](https://github.com/genuinetools/img), and [buildkit](https://github.com/moby/buildkit).
@@ -200,14 +187,12 @@ Therefore the most important rule is to apply a multi-step process for your spec
 
 First, you want to determine if there is an already existing container that you can use, and in this case, use it and add to your workflow documentation instructions for doing so.
 As an example, you might be doing some kind of interactive development.
-For interactive development environments such as notebooks and development servers or databases, you can readily find containers that come installed with
-all the software that you need.
-You look for information about images (a) in the documentation of the used software, (b) the Docker image registry _Docker Hub_, [https://hub.docker.com/](https://hub.docker.com/), or (c) in the source code projects of the used software, as many developers today rely on containers for development, testing, and teaching.
+For interactive development environments such as notebooks and development servers or databases, you can readily find containers that come installed with all the software that you need.
+You can look for information about images in (a) the documentation of the used software, (b) the Docker image registry _Docker Hub_, [https://hub.docker.com/](https://hub.docker.com/), or (c) the source code projects of the used software, as many developers today rely on containers for development, testing, and teaching.
 
 Second, in the case that there isn't an existing container for your needs, you might next look to well-maintained tools to help with `Dockerfile` generation.
 These tools can add required software packages to an existing image without you having to manually write a `Dockerfile` at all.
-"Well-maintained" includes the tool's own stability and usability, but also that suitable base images are used, likely from the official Docker library
-[@docker_inc_official_2019], to ensure that the container has the most recent security fixes for the operating system in question.
+"Well-maintained" references the tool's own stability and usability, but also that suitable base images are used, likely from the official Docker library [@docker_inc_official_2019], to ensure that the container has the most recent security fixes for the operating system in question.
 See below box "Tools for container generation" for details.
 
 Third, you may want to write you own `Dockerfile` if these tools do not suffice for your needs.
@@ -226,16 +211,16 @@ jupyter-repo2docker https://github.com/norvig/pytudes
 ```
 
 The resulting container image installs the dependencies listed in the requirements file, along with providing an entrypoint to run a notebook server to interact with any existing workflows in the repository.
-Since repo2docker is used within [MyBinder.org](https://mybinder.org/), if you make sure your workflow is "Binder-ready", you and others can also get an online workspace with a single click.`
+Since repo2docker is used within [MyBinder.org](https://mybinder.org/), if you make sure your workflow is "Binder-ready", you and others can also get an online workspace with a single click.
 A precaution that needs to be taken is that the default command above will create a home for the current user, meaning that the container itself would not be ideal to share, but rather any researchers interested in interaction with the code inside should run repo2docker themselves and create their own container.
 Because repo2docker is deterministic, the environments are the same (see&nbsp;\ruleref{rule:pinning} for ensuring the same software versions).
-<!--For this reason, it is good practice to look at any help command provided by the tool and check for configuration options for user names, user ids, and similar.
-It's also recommended to add custom labels to your container build to define metadata for your analyses even if you are using tools (see&nbsp;\ruleref{rule:metadata}).-->
 
 Additional tools to assist with writing `Dockerfile`s include `containerit` [@nust_containerit_2019] and `dockta` [@stencila_dockta_2019].
 `containerit` automates the generation of standalone `Dockerfile`s for workflows in R.
 It can provide a starting point for users unfamiliar with writing `Dockerfile`s, or together with other R packages provide a full image creation and execution process without having to leave an R session.
 `dockta` supports multiple programming languages and configurations files, just as `repo2docker`, but attempts to create readable `Dockerfile`s compatible with plain Docker and to improve user experience by cleverly adjusting instructions to reduce build time.
+For any tool that you use, be sure to look at documentation for usage and configuration options, and options to add metadata (e.g., labels see&nbsp;\ruleref{rule:metadata}).
+
 
 ------
 
@@ -245,32 +230,22 @@ It can provide a starting point for users unfamiliar with writing `Dockerfile`s,
 A good understanding of how base images and image tags work is crucial, as the image and tag that you choose has important implications for your container.
 It's good practice to use base images that are maintained by the Docker library, so called _"official images"_ [@docker_inc_official_2020], which benefit from a review for best practices and vulnerability scanning [@docker_inc_best_2020].
 You can identify these images by the missing the user portion of the image name, which comes before the `/`, e.g., `r-base` or `python`.
-However, these images only provide basic programming languages or very widely used software.
-So you will likely use images maintained by organisations or fellow researchers.
-While some organisations can be trusted to update containers with security fixes (see list below), for most individual accounts that provide ready to use images, it is likely that these will not be updated regularly.
+However, these images only provide basic programming languages or very widely used software, so you will likely use images maintained by organizations or fellow researchers.
+While some organizations can be trusted to update containers with security fixes (see list below), for most individual accounts that provide ready to use images, it is likely that these will not be updated regularly.
 It is even possible that images or `Dockerfile`s may disappear, or that images are published with malicious intent, though we have not heard of any such case in academia.
-Therefore, for security, transparency, and reproducibility, you should only use images where you have access to the `Dockerfile`.
-Do save a copy of the `Dockerfile`, e.g., by cloning the public repository where the `Dockerfile`s are maintained.
+Therefore, for security, transparency, and reproducibility, you should only use images where you have access to the `Dockerfile`, and it is suggested to save a copy of the `Dockerfile` in the case that a repository or other distribution goes away.
 
-Images have _tags_ associated with them with specific meanings, e.g., a version indicator such as `1.2` or `dev`, or variants such as `slim` attempting to reduce image size.
-Tags are defined at image built time and appear in image name after the `:` when you use an image, e.g., `python:1.2`.
+Images have _tags_ associated with them with specific meanings, e.g., a version indicator such as `3.7` or `dev`, or variants such as `slim` attempting to reduce image size.
+Tags are defined at image built time and appear in image name after the `:` when you use an image, e.g., `python:3.7`.
 By _convention_ a missing tag is assumed to be the word `latest`, which gives you the latest updates but also a moving target for your computing environment that can break your workflow.
-Note that a version tag means that the tagged software is frozen, but it does not mean the image will not change, as backwards compatible fixes (cf.&nbsp;semantic versioning, [@preston-werner_semantic_2013]), e.g., version `1.2.3` fixing a security problem in version `1.2.2` or updates to an underlying system library, will still be included.
+Note that a version tag means that the tagged software is frozen, but it does not mean the image will not change, as backwards compatible fixes (cf.&nbsp;semantic versioning, [@preston-werner_semantic_2013]), e.g., version `1.2.3` fixing a security problem in version `1.2.2` or updates to an underlying system library, would be published to the parent tag `1.2`.
 
 For data science workflows, you should always rely on version-specific image tags both for base images that you use, and for images that you build yourself and then run.
-Also do not worry about image size, because the size will be often be much smaller than the data anyway.
-<!--When you re-build you images locally using the same tag, the tag is always associated with the newest built.
-But the image also has an automatically generated image name using a hash, which will _not_ be updated.´
-So if you tag an image, use the tag when you start a container.-->
-<!--You should know how to use `FROM` instructions to trace all the way up to the original container base, an abstract base called `scratch`.
-Doing this kind of trace is essential because it makes clear all of the steps that were taken to generate your container and who took them.
-If you want to build on a third party image, carefully consider the author/maintainer and _never_ use an image without a published `Dockerfile`.
-If you want to use an unofficial image, do save a copy of the `Dockerfile`s created by others.-->
-It is good practice to publish an image in an image registry, and we refer you to the documentation on automated builds for details, see [Docker Hub Builds](https://docs.docker.com/docker-hub/builds/) or [GitLab's Container Registry](https://docs.gitlab.com/ee/user/packages/container_registry/index.html#build-and-push-images).
+With keeping different versions (tags) available, it is good practice to publish an image in an image registry.
+We refer you to the documentation on automated builds for details, see [Docker Hub Builds](https://docs.docker.com/docker-hub/builds/) or [GitLab's Container Registry](https://docs.gitlab.com/ee/user/packages/container_registry/index.html#build-and-push-images) as well as CI platforms such as [GitHub actions](https://github.com/actions/starter-workflows/tree/master/ci), or [CircleCI](https://circleci.com/orbs/registry/orb/circleci/docker#commands-build) that can help you get started.
 Do not `docker push` a locally built image, because that counteracts the considerations outlined above.
 If a pre-built image is provided in a public image registry, do not forget to direct the user to it in your documentation, e.g. in the `README` file or in an article.
-<!--as well as CI platforms such as [GitHub actions](https://github.com/actions/starter-workflows/tree/master/ci) or [CircleCI](https://circleci.com/orbs/registry/orb/circleci/docker#commands-build) can help you get started; tools may also be available to automate builds using intermediate tools, such as the `repo2docker` Github action [@husain_repo2docker-action_2019; @scottyhq_repo2docker-githubci_2019],
--->
+
 <!--When you choose a base image, try to choose one with a Linux distribution that supports the software stack you are using, and also take into account the bases that are widely used by your community.
 As an example, Ubuntu is heavily used for geospatial research, and so the `rocker/geospatial` image would be a good choice for spatial data science with R, or `jupyter/tensorflow-notebook` could be a good choice for machine learning with Python.-->
 <!--If you do not want to rely on a third party or other individual to maintain the recipe and container, you should copy the `Dockerfile` to your own repository, and also provide a deployment for it via your own automated build.
@@ -285,13 +260,13 @@ Do take advantage of images with complex software environments pre-installed, e.
 - [Jupyter Docker Stacks](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html) for Notebook-based computing
 - [Taverna Server](https://hub.docker.com/r/taverna/taverna-server) for running Taverna workflows
 
-For example, here is how we would use a base image `verse`, which provides the populary Tidyverse suite of packages [@Wickham2019], with R version `3.5.2` from the `rocker` organisation on Docker Hub (`docker.io`, which is the default and can be omitted).
+For example, here is how we would use a base image `verse`, which provides the populary Tidyverse suite of packages [@Wickham2019], with R version `3.5.2` from the `rocker` organization on Docker Hub (`docker.io`, which is the default and can be omitted).
 
 ```
 FROM docker.io/rocker/r-ver:3.5.2
 ```
 
-# 3. Fomat intentionally and favour clarity
+# 3. Format intentionally and favor clarity
 \rulelabel{3}{rule:formatting}
 \rulelabel{3}{rule:clarity}
 
@@ -306,37 +281,30 @@ When you need to change a directory, use `WORKDIR`, because it not only creates 
 Second, clarity is nearly always more important than brevity.
 For example, if your container uses a script to run a complex install routine, instead of removing it from the container upon completion, which is commonly seen in production `Dockerfile`s aiming at small image size, you should keep the script in the container for a future user to inspect.
 A common pattern you might encounter is a single `RUN` instruction that updates the database of available packages, installs a software from a package repository, and then purges the cache of the package manager.
-For 
+
 Depending on the programming language used, your project may already contain files to manage dependencies and you may use a package manager to control this aspect of the computing environment.
-This is a very good practice and helpful, though you should consider the externalisation of content to outside of the `Dockerfile` (see \ruleref{rule:mount}).
+This is a very good practice and helpful, though you should consider the externalization of content to outside of the `Dockerfile` (see \ruleref{rule:mount}).
 A single long `Dockerfile` with sections and helpful comments can be complete and thus more understandable than a collection of separate files.
 
 Generally, aim to design the `RUN` instructions so that each performs one scoped action, e.g., download, compile, and install _one tool_.
 Each instruction will result in a new layer, and reasonably grouped changes increase readability of the `Dockerfile` and facilitate inspection of the image, e.g., with tools like dive [@goodman_dive_2019].
 Convoluted `RUN` instructions can be acceptable to reduce the number of layers, but careful layout and consistent formatting should be applied (see \ruleref{rule:formatting}).
-A `RUN` instruction not fully visible on your screen requires scrolling and thereby diminishes readability.
-This may be challenging for the next reader to digest and you should consider splitting it up, accepting the extra layers added to the image.
 
-While you will find `Dockerfile`s using [_build-time variables_](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) to dynamically change parameters at build time, such a customisation option reduces clarity for data science workflows based on research compendia.
+While you will find `Dockerfile`s using [_build-time variables_](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) to dynamically change parameters at build time, such a customization option reduces clarity for data science workflows based on research compendia.
 
 # 4. Document within the Dockerfile
 \rulelabel{3}{rule:document}
 
 ## Comments
 
-<!--You can use a linter [@wikipedia_contributors_lint_2019] to avoid small mistakes and follow good practices from software development communities.
-The consistency added by linting also helps keeping your edits to a `Dockerfile` in a VCS meaningful (see \ruleref{rule:publish}).
-Note however that a linter's rules may not primarily serve the intention of reproducible scientific workflows.-->
-As you are writing the `Dockerfile`, be mindful of how other people will read it and why.
-Are your choices and commands being executed clear, or is further comment warranted?
-To assist others in making sense of your `Dockerfile`, you can add comments that include links to online forums, code repository issues, or VCS commit messages to give context for your specific decisions.
+As you are writing the `Dockerfile`, be mindful of how other people (including future you!) will read it and why.
+Are your choices and commands being executed clearly, or is further comment warranted?
+To assist others in making sense of your `Dockerfile`, you can add comments that include links to online forums, code repository issues, or version control commit messages to give context for your specific decisions.
 For example [this `Dockerfile` by Kaggle](https://github.com/Kaggle/docker-rstats/blob/master/Dockerfile) does a good job at explainig the reasoning and steps of the contained instructions.
-Comments should include helpful usage guides and links for readers inspecting the `Dockerfile`, including future you.
-For example, if you copy instructions from another `Dockerfile`, acknowledge the source in a comment.
-<!--The official images and images by established organisations should be your preferred source of snippets if you craft you own `Dockerfile`.-->
+If you copy instructions from another `Dockerfile`, acknowledge the source in a comment.
 It can even be helpful to include comments about commands that did not work so you do not repeat past mistakes.
 If you find that you need to remember an undocumented step, that is an indication that it should be documented in the `Dockerfile`.
-All instructions can be grouped starting with a short comment, which also makes it easier to spot changes if your `Dockerfile` is managed in a VCS (see \ruleref{rule:publish}).
+All instructions can be grouped starting with a short comment, which also makes it easier to spot changes if your `Dockerfile` is managed in some version control system (see \ruleref{rule:publish}).
 
 Here is a selection of typical kinds of comments that are useful to include in a `Dockerfile`:
 
@@ -369,7 +337,7 @@ You can view all labels with [`docker inspect`](https://docs.docker.com/engine/r
 Labels serve as structured metadata that can be leveraged by services, e.g., https://microbadger.com/labels.
 For example, software versions, license, and maintainer contact information are commonly seen and very useful if a `Dockerfile` is discovered out of context.
 While you can add arbitrarily complex information with labels, for research compendia the user-facing documentation is much more important.
-If you want to earn extra points, and you never know what future algorithms will be able to make sense of, include global identifiers such as [ORCID identifiers](https://orcid.org/) for people, a DOI of the research compendium, e.g., [reserved on Zenodo](https://help.zenodo.org/) before publishing the research compendium, or your funding agency's grant number.
+Important metadata that might be more utilized with future tools includes global identifiers such as [ORCID identifiers](https://orcid.org/), DOIs of the research compendium, e.g., [reserved on Zenodo](https://help.zenodo.org/), or a funding agency's grant number.
 
 The OCI Image Format Specification provides some common label keys (see the "Annotations" section in @opencontainers_image-spec_2017) to help standardise field names across container tools, as shown below.
 These labels match the [`org.label-schema`-specification](http://label-schema.org/rc1/), which has been deprecated but is still found a lot in `Dockerfile`s.
@@ -397,20 +365,16 @@ LABEL maintainer="daniel.nuest@uni-muenster.de" \
 
 ## Usage instructions
 
-It is often helpful to provide usage instructions, i.e., how to `docker build` and `docker run` the image, _within_ the `Dockerfile`.
-Such documentation is especially relevant if volume mounts or ports are important for using the container, see for example the final lines of Listing&nbsp;1.
-By putting the usage documentation at the end of the file, they are easy to copy-paste after a container build when you are likely to have the `Dockerfile` open, and, most importantly, they can be kept in consistent state compared to documentation in another file.
-This helps both you and others.
-It helps you when you pick up a previously written `Dockerfile` and for example do not remember the container identifier you used, it would be represented in the `Dockerfile` in the `--name` parameter, preserved in a comment.
+It is often helpful to provide usage instructions, i.e., how to `docker build` and `docker run` the image, _within_ the `Dockerfile`, either at the top or bottom where the reader is likely to find it.
+Such documentation is especially relevant if volume mounts, specific names, or ports are important for using the container, see for example the final lines of Listing&nbsp;1.
 Following a common coding aphorism, we might say _"A Dockerfile written three months ago may just as well have been written by someone else"_.
 It helps others, because it quickly gets them running your workflow and interacting with the container in the intended way without reading all of the instructions (a ["tl;dr"](https://en.wikipedia.org/wiki/Wikipedia:Too_long;_didn%27t_read)-kind of usage).
-Your documentation, e.g. `README` file, should not duplicate this information alongside the `Dockerfile` for exactly how to build, run, and otherwise interact with the container but instead point to the `Dockerfile`.
-Duplicate usage instructions with eventually diverge and lead to frustration, and referring to the `Dockerfile` has the added advantage that you point your reader to it, demonstrating your careful work habits and good intentions for transparency and computational reproducibility.
+The `Dockerfile` alongside your documentation strategy is a demonstration of your careful work habits and good intentions for transparency and computational reproducibility.
 
 # 5. Order instructions
 \rulelabel{5}{rule:order}
 
-You will regularly build an image more during development of your workflow.
+You will regularly build an image during development of your workflow.
 You can take advantage of _build caching_ to avoid execution of time-consuming instructions, e.g., install from a remote resource or a copying a file that gets cached.
 Therefore you should add instructions _in order_ of least likely to change to most likely to change.
 Docker will execute the instructions in the order as they appear in the `Dockerfile`.
@@ -435,7 +399,7 @@ A recommended ordering based on these considerations is as follows.
 \rulelabel{6}{rule:pinning}
 
 The reproducibility of your `Dockerfile` heavily depends on how well you define the versions of software to be installed in the image.
-The more specific, the better, because using the desired version leads to reproducible builds.
+The more specific the better, because using the desired version leads to reproducible builds.
 The practice of specifying versions of software is called _version pinning_ (e.g., on `apt`: https://blog.backslasher.net/my-pinning-guidelines.html).
 For stable workflows in a scientific context, it is generally advised to freeze the computing environment explicitly and not rely on the "current" or "latest" software, which is a moving target.
 
@@ -483,8 +447,8 @@ serves as more clear documentation in a `Dockerfile` than a `requirements.txt` f
 RUN pip install -r requirements.txt
 ```
 
-This modularisation is a potential risk for understandability and consistency, which can be mitigated by carefully managing all these files in the same version-controlled project.
-You can also use package manager to install software from source code `COPY`ied into the image (see&nbsp;\ruleref{rule:mount}).
+This modularization is a potential risk for understandability and consistency, which can be mitigated by carefully managing all these files in the same version-controlled project.
+You can also use package managers to install software from source code `COPY`ied into the image (see&nbsp;\ruleref{rule:mount}).
 And finally, you can use many package managers to install software from source obtained from code management repositories, e.g., installing a specific tool identified by a GitHub version tag or commit hash.
 Be aware of the risk of depending on such repositories, especially if they are out of your control, although the installation command with a full URL should allow readers of your `Dockerfile` to dig deeper if problems arise.
 Such an installation from source gives you a lot of freedom, including the one to shoot yourself in the foot.
@@ -492,16 +456,16 @@ The version pinning capabilities of these file formats and package managers are 
 
 As a final note on software installation, you should be aware of the [`USER` instruction](https://docs.docker.com/engine/reference/builder/#user) in a `Dockerfile` and how your base image might adjust the user to enable particular usages.
 It is common to use images with the default user `root`, e.g., , `root` is required for installing system dependencies.
-We recommend to make sure the image works without specifying a users, and to document precisely if your image deviates from that.
+We recommend to make sure the image works without specifying any users, and to document precisely if your image deviates from that.
 One reason you will encounter base images running a non-root user (popular examples are the Jupyter and Rocker image stacks) is to avoid permission problems when mounting files into the container, especially for "output" files (see&nbsp;\ruleref{rule:mount}).
 
 # 7. Mount user scripts and data {-}
 \rulelabel{7}{rule:mount}
 
-The role of containers is to provide the computing environment, not to encapsulate datasets or control scripts.
-It is better to insert data files and scripts files from the local machine into the container at run time, and using the container image primarily for the software and dependencies.
+The role of containers is to provide the computing environment, not to encapsulate datasets or custom scripts.
+It is better to insert data files and custom scripts files from the local machine into the container at run time, and using the container image primarily for the software and dependencies.
 This insertion is achieved by using [_bind mounts_](https://docs.docker.com/storage/bind-mounts/).
-Mounting these files is preferable to using the `ADD`/`COPY` instructions in the `Dockerfile`, because files persist when the container instance or image is removed from your system, and the files are more accessible when the workspace is published as a research compendium.
+Mounting these files is preferable to using the `ADD`/`COPY` instructions in the `Dockerfile`, because files persist when the container instance or image is removed from your system, and the files are more accessible when the workspace is published.
 If you want to add local files to the container, prefer `COPY` because it is explicit and you do not need `ADD`'s extra features, which are (i) URL as a source, for which you may use it instead of a `RUN wget` or `RUN curl` to download files, and (ii) a local [tar file](https://en.wikipedia.org/wiki/Tar_(computing)) as a source, which you should avoid because such an archive file will be harder for future readers of your `Dockerfile` to make sense of and cannot be properly version controlled.
 Unless specific features are needed, bind mounts are also preferable to [storage volumes](https://docs.docker.com/storage/volumes/).
 
@@ -513,8 +477,8 @@ If you cannot publish a software project albeit it being in a language's package
 
 Storing _data files_ outside of the container allows handling of very large datasets and datasets with data worthy of protection, e.g., proprietary data or private information.
 Do not include such data in an image.
-To avoid publishing sensitive data by accident, you can add the data directory to the [`.dockerignore`](https://docs.docker.com/engine/reference/commandline/build/#use-a-dockerignore-file) file, which excludes files and directories from the [build context](https://docs.docker.com/engine/reference/commandline/build/#extended-description), i.e., the set of files considered by `docker build`.
-Ignoring data files also speeds up the build in case of very large files or many small files, the latter of which makes it common to ignore for example the `.git` folder of the Git VCS.
+To avoid publishing sensitive data by accident, you can add the data directory to the [`.dockerignore`](https://docs.docker.com/engine/reference/commandline/build/#use-a-dockerignore-file) file that excludes files and directories from the [build context](https://docs.docker.com/engine/reference/commandline/build/#extended-description), i.e., the set of files considered by `docker build`.
+Ignoring data files also speeds up the build in case of very large files or many small files, the latter of which makes it common to ignore for example the `.git` folder of the Git version control system.
 You should include dummy or test data into the image to be able to ensure that a container is functional without a larger custom dataset, e.g., for automated tests or instructions in the user manual.
 For all these cases you should provide clear instructions for users in the `README` how to obtain actual or dummy data.
 When publishing your workspace, e.g., on Zenodo, having data and script contents as regular files outside of the container makes them more accessible to others, for example for reuse or analysis.
@@ -550,10 +514,11 @@ For example, @verstegen_pluc_mozambique_2019 demonstrates a container for runnin
 A workflow that does not support headless execution may even be seen as irreproducible.
 
 These two usages can be configured by the `Dockerfile`'s author and exposed to the user based on the `Dockerfile`'s `CMD` and `ENTRYPOINT` instructions.
-An images main purpose is reflected by the default process and configuration, though the `CMD` and `ENTRYPOINT` can also be changed at runtime.
+An image's main purpose is reflected by the default process and configuration, though the `CMD` and `ENTRYPOINT` can also be changed at runtime.
 It is considered good practice to have a combination of default command and entrypoint that meets reasonable user expectations.
-For example, a container known to be a workflow should execute the workflow, or provide instructions for how to do so.
-Since you are likely the primary user of the `Dockerfile` and image, so you should choose a selection or combination that works for you, only then accomodate other user's needs.
+For example, a container known to be a workflow should execute the entrypoint to the workflow, and perhaps use `--help` as the command to print out usage.
+The container entrypoint should _not_ execute the workflow, as the user is likely to run the container for basic inspection, and starting an analysis as a surprise that might write files is undesired.
+As the maintainer of the workflow, you should write clear instructions for how to properly interact with the container, both for yourself and others.
 A possible weakness with using containers is the limitation on only providing one default command and entrypoint.
 However tools, e.g., The Scientific Filesystem [@sochat_scientific_2018], have been developed to expose multiple entrypoints, environments, help messages, labels, and even install sequences.
 With plain Docker, you can override the defaults as part of the `docker run` command or in an extra `Dockerfile` using the primary image as a base, as shown in Listing&nbsp;2.
@@ -609,7 +574,7 @@ A person who is unfamiliar with Docker but wants to use your image may rely on g
 _Interactive usage of a command-line interfaces_ is quite straightforward to access from containers, if users are familiar with this style of user interface.
 Running the container will provide a shell where a tool can be used and help or error messages can assist the user.
 For example, complex workflows in any programming language can, with suitable pre-configuration, be triggered by running a specific script file.
-If your workflow can be executed via a CLI you may use that to validate correct functionality of an image in automated builds, e.g. using a small toy example and checking the output, by checking successful responses from HTTP endpoints provided by the container, e.g. via an HTTP response code of `200`, or by using a controller such as Selenium [@selenium_2019].
+If your workflow can be executed via a command line client you may use that to validate correct functionality of an image in automated builds, e.g. using a small toy example and checking the output, by checking successful responses from HTTP endpoints provided by the container, e.g. via an HTTP response code of `200`, or by using a controller such as Selenium [@selenium_2019].
 
 The followig example runs a simple R command counting the lines in this articles source file.
 The file path is passed as an environment variable.
@@ -638,54 +603,42 @@ This variety of approaches render seemingly more convenient uncontainerised envi
 # 9. Use a Dockerfile per project and publish it with a version control system {-}
 \rulelabel{9}{rule:publish}
 
-Because a `Dockerfile` is a plain text-based format, it works well with VCS.
-Including a `Dockerfile` alongside your code and data in a research compendium is an effective way to consistently build your software, to show visitors to the repository how it is built and used, to solicit feedback and collaborate with your peers, and to increase the impact and sustainability of your work (cf. @emsley_framework_2018).
+Because a `Dockerfile` is a plain text-based format, it works well with version control systems.
+Including a `Dockerfile` alongside your code and data is an effective way to consistently build your software, to show visitors to the repository how it is built and used, to solicit feedback and collaborate with your peers, and to increase the impact and sustainability of your work (cf. @emsley_framework_2018).
 Online collaboration platforms (e.g., GitHub, GitLab) also make it easy to use CI services to test building and executing your image in an independent environment.
 Continuous integration increases stability and trust, and gives the ability to publish images automatically.
-If your `Dockerfile` includes an interactive user interface, you can also adapt it so that it is ready-to-use as a Binder instance [@jupyter_binder_2018], providing an online work environment to any user with a simple click of a link.
 Furthermore, the commit messages in your version controlled repository preserve a record of all changes to the `Dockerfile`.
 
 While there are exceptions to the rule (cf.&nbsp;@kim_bio-docklets_2017), it's generally a simple and clear approach to provide one `Dockerfile` per project.
 Alternatively, you could build an _image stack_ to serve different use cases with a common base image, but this reduces understandability and scatters information across multiple places.
 We recommend to avoid this at the price of a longer `Dockerfile` and mitigate with consistent form (see&nbsp;\ruleref{rule:formatting}).
-<!--If you find that you really need to use more than one container to run your workflow, use `docker-compose`.
-Carefully consider if build-time variables to flip between states (e.g., development vs. production, see&nbsp;\ruleref{rule:interactive}) or to separate tools into different repositories could help, but be aware of their disadvantages.-->
-Yet most importantly, you should publish _all_ files `COPY`ied into the container, e.g., test data or files for software installation from source (see&nbsp;\ruleref{rule:mount}), in the same research compendium.
+Importantly, you should publish _all_ files `COPY`ied into the container, e.g., test data or files for software installation from source (see&nbsp;\ruleref{rule:mount}), in the same research compendium.
 
 It is likely going to be the case that over time you will develop workflows that are similar in nature to one another.
 When developing or working on projects with containers you can switch between isolated project environments by stopping the container and restarting it when you are ready to work again, even on another machine or in a cloud environment.
-You can even run projects in parallel without interference.
+You can even run projects in parallel that don't share ports without interference.
 In case you feel like constantly repeating yourself, you should consider adopting a standard workflow that will give you a clean slate for a new project.
 As an example, cookie cutter templates [@cookiecutter_contributors_cookiecutter_2019], project starter kits [REF], or community templates (e.g., [@marwick_rrtools_2019]) can provide required files, e.g., for documention, CI, and licenses, and structure for getting started.
-<!--In the case of using a common `Dockerfile` or base, Docker's build caching will take shared lines into account and speed up build time even between projects.-->
-If you decide to build your own best practice, consider to collaborate with your community during development of the standard to ensure it will be useful to others.
+If you decide to build your own cookie cutter template, consider collaborating with your community during development of the standard to ensure it will be useful to others.
 Part of your project template should be a protocol for publishing the `Dockerfile` and even an export of the image in a suitable location, e.g., a container registry or data repository, taking into consideration of how your workflow can receive a DOI for citation.
 
 # 10. Use the container daily, rebuild the image weekly, clean up and preserve if need be {-}
 \rulelabel{10}{rule:usage}
 
-Using containers for research workflows does not only require technical understanding, but also an awareness of risks that can be managed efficiently by following a number of good _habits_, which we outline below.
+Using containers for research workflows does not only require technical understanding, but also an awareness of risks that can be managed efficiently by following a number of good _habits_, discussed in this section.
 While there is no firm rule, if you use a container daily, is good practice to rebuild that container every once or two weeks.
 At the time of publication of research results it is good practice to save a copy of the image in a public data repository so that readers of the publication can access the resources that produced the published results. 
 
-First, use your container every time you work on a project and not just as a final step during publication.
+First, it is a good habit to use your container every time you work on a project and not just as a final step during publication.
 If the container is the only platform you use, the confidence in proper documentation of the computing environment can be very high [@marwick_readme_2015].
-You should prioritise this usage over others, e.g., non-interactive execution of a full workflow, because it gives you personally the highest value and does not limit your use or others' use of your data and code at all (see \ruleref{rule:interactive}).
+You should prioritize this usage over others, e.g., non-interactive execution of a full workflow, because it gives you personally the highest value and does not limit your use or others' use of your data and code at all (see \ruleref{rule:interactive}).
 
 Second, for reproducibility, we can treat containers as transient and disposable, and even intentionally rebuild an image at regular intervals.
-Ideally, containers that we built years ago should rebuild seamlessly, but this is not necessarily the case, especially with rapidly changing technology relevant to machine learning and data science.
-It can almost be guaranteed  future changes will interfere with the image build process or even the functionality of the software within the image.
-The longer that you wait to rebuild the image, the more change happens, the higher the risk that your build will not work, and the harder it becomes to identify and fix the problem.
-If you are using an interactive container and find that you need to manually install a package or change a parameter, it is best practice to add this dependency to the container and rebuild it right away, but one tends to take shortcuts.
-Therefore, a habitual deletion of a container and cache-less rebuild of the image (a) increases security due to updating underlying software, (b) helps to reveals issues requiring manual interference, i.e., changes to code or configuration not documented in the `Dockerfile` but perhaps should be, and (c) allows you to more incrementally debug issues.
+Ideally, containers that we built years ago should rebuild seamlessly, but this is not necessarily the case, especially with rapidly changing technology relevant to machine learning and data science. 
+A habitual deletion of a container and cache-less rebuild of the image (a) increases security due to updating underlying software, (b) helps to reveals issues requiring manual interference, i.e., changes to code or configuration not documented in the `Dockerfile` but perhaps should be, and (c) allows you to more incrementally debug issues.
 This habit can be supported by using continuous deployment or CI strategies.
-If a VCS repository with a `Dockerfile` is linked to an automated build, then a CI pipeline can build images and execute a validating run the new image, e.g., using contained demo data (see&nbsp;\ruleref{rule:mount}).
 
 In the case of needing setup or configuration for the first two habits, it is good practice to provide a `Makefile` alongside your container, which can capture the specific commands.
-The effective use of a `Makefile` can help avoiding undocumented steps or manual, extra commands to be run on the local machine.
-A fully scripted configuration makes it easier for both you and future users, and can increase trust in your workflow.
-If you use a `Makefile`, consider pointing to it instead of adding usage instructions in a comment at the end of the `Dockerfile`.
-A `Makefile` will also help you to take advantage of build-time variables in a useful way (unlike \ruleref{rule:favour}) for inserting specific metadata into an image, e.g., the current VCS [commit hash]() or a timestamp.
 
 Third, from time to time you can reduce the system resources occupied by Docker images and their layers or unused containers, volumes and networks by running `docker system prune --all`.
 After a prune is performed, it follows naturally to rebuild a container for local usage, or to pull it again from a newly built registry image.
@@ -693,14 +646,10 @@ This habit can be automated with a cron job [@wikipedia_contributors_cron_2019].
 
 <!-- [SJE:  "sure, okay, I'd like to export an image.  Give me a recipe to show me how to do it, e.g. for this paper!"] -->
 Fourth, you can export the image to file and deposit it in a public data repository, where it not only becomes citable but also provides a snapshot of the _actual_ environment you used at a specific point in time.
-You should include instructions how to import and run the workflow based on the image archive and add your own image tags for clarity.
+You should include instructions for how to import and run the workflow based on the image archive and add your own image tags for clarity.
 Depositing the image next to other project files, i.e., data, code, and the used `Dockerfile`, in a public repository makes them likely to be preserved, but is is highly unlikely that over time you will be able to recreate it precisely from the accompanying `Dockerfile`.
 Publishing the image and the contained metadata therein (e.g., the Docker version used) may even allow future science historians to emulate the Docker runtime environment.
-Applying proper preservation strategies (cf. [@emsley_framework_2018]) can be highly complex, but simply running an image "as-is", i.e. with the default command and entrypoint (see \ruleref{rule:interactive}), and observing the output is quite likely to work for many years into the future.
-If the image does not work anymore, a user can still extract the image contents and explore the files of each layer manually, or if an import still works, with exploration tools like dive [@goodman_dive_2019].
-However, if you want to ensure usability and extendability, then you could run import, run, and export an image regularly to make sure the export format still works with the then current version of Docker.
-
-The exported image and a version controlled `Dockerfile` together allow you to freely experiment and continue development of your workflow and keeping the image up to date, e.g., updating versions of pinned dependencies (see \ruleref{rule:pinning}) and regular image building (see above).
+Sharing the actual image via a registry and a version controlled `Dockerfile` together allow you to freely experiment and continue development of your workflow and keeping the image up to date, e.g., updating versions of pinned dependencies (see \ruleref{rule:pinning}) and regular image building (see above).
 
 Finally, for a sanity check and to foster even higher trust in the stability and documentation of your project, you can ask a colleague or community member to be your code copilot (see [https://twitter.com/Code_Copilot](https://twitter.com/Code_Copilot)) to interact with your workflow container on a machine of their own.
 You can do this shortly before submitting your reproducible workflow for peer-review, so you are well positioned for the future of scholarly communication and open science where these may be standard practices required for publication [@eglen_codecheck_2019; @chen_open_2019; @schonbrodt_training_2019; @eglen_recent_2018].
@@ -711,14 +660,12 @@ To demonstrate the ten rules, we maintain a collection of annotated example `Doc
 
 # Conclusion {#conclusion .unnumbered}
 
+In this article we have provided guidance for using `Dockerfile`s to create containers for use and communication in smaller scaled data science research.
 Reproducibility in research is an endeavor of incremental improvement and best efforts, not about achieving the perfect solution, which may be not achievable for many researchers with limited resources, and the definition of which may change over time.
-Containerisation can support researchers.
-Containers can be optimised for very different use cases, such as supporting many hosts, being small in size for quick deployments in cloud infrastructures, but in this article we have provided guidance for using `Dockerfile`s to create containers for use and communication in computational research.
-Our goal is to help the researcher to work towards creating a "time capsule" [@blank_twitter_2019] in form of a research compendium.
-Given some expertise and the right tools, such a compendium can come as close as needed to the original workflow with reasonably little effort for better science.
-Even if such a capsule decays over time, the effort to create and document it provides incredibly useful and valuable transparency for the project.
-We encourage researchers to value these steps taken by their peers to use `Dockerfile`s to create "time capsules", and promote change in the way scholars communicate towards an open and friendly "preproducibility" [@stark_before_2018].
-So please, make a best effort with your current knowledge, and strive to write readable `Dockerfile`s for functional containers, that are realistic about what might break and what is unlikely to break.
+Containers can support researchers, and can be optimized for very different use cases, such as supporting many hosts, or being small in size for quick deployments in cloud infrastructures.
+Even if imperfect, the effort to create and document scientific workflows provides incredibly useful and valuable transparency for the project.
+We encourage researchers to value these steps taken by their peers to use `Dockerfile`s to practice reproducible research, and promote change in the way scholars communicate towards an open and friendly "preproducibility" [@stark_before_2018].
+So please, make a best effort with your current knowledge, and strive to write readable `Dockerfile`s for functional containers that are realistic about what might break and what is unlikely to break.
 In a similar vein, we accept that you should freely break these rules if another way makes more sense _for your use case_.
 Most importantly, share and exchange your `Dockerfile` freely and collaborate in your community to spread the knowledge about containers as a tool for research and scholarly collaboration and communication.
 Together we can develop common practices and shared materials for better transparency, higher efficiency, and faster innovation.

--- a/ten-simple-rules-dockerfiles.Rmd
+++ b/ten-simple-rules-dockerfiles.Rmd
@@ -65,7 +65,7 @@ This sharing of code files is enabled by collaboration platforms such as [GitHub
 The sharing of the computing environment, on the other hand, is enabled by containerization, which allows for documenting and sharing entire workflows in a comprehensive way.
 This sharing of computational assets is paramount to increase reproducibility of computational resarch.
 While "papers" based on the traditional journal article format can share high level details of research, computational research is oftentimes way too complicated to be disseminated alongside in this format [@marwick_how_2015]. 
-In that the actual contribution to knowledge includes the full computing environment that produced a result, containerization is needed [@donoho_invitation_2010].
+In that the actual contribution to knowledge includes the full computing environment that produced a result [@donoho_invitation_2010], containerization is needed.
 
 Containerization plays an important role in providing instructions for packaging the building blocks of computer-based research (i.e. code, data, documentation, and the computing environment). While a container cannot package all of these blocks, it represents a human- _and_ machine-readable recipe to capture the computing environment and interact with data.
 By providing this recipe, authors of scientific articles greatly improve their work's level of documentation, transparency, and reusability.

--- a/ten-simple-rules-dockerfiles.Rmd
+++ b/ten-simple-rules-dockerfiles.Rmd
@@ -67,7 +67,8 @@ This sharing of computational assets is paramount to increase reproducibility of
 While "papers" based on the traditional journal article format can share high level details of research, computational research is oftentimes way too complicated to be disseminated alongside in this format [@marwick_how_2015]. 
 In that the actual contribution to knowledge includes the full computing environment that produced a result [@donoho_invitation_2010], containerization is needed.
 
-Containerization plays an important role in providing instructions for packaging the building blocks of computer-based research (i.e. code, data, documentation, and the computing environment). While a container cannot package all of these blocks, it represents a human- _and_ machine-readable recipe to capture the computing environment and interact with data.
+Containerization plays an important role in providing instructions for packaging the building blocks of computer-based research (i.e. code, data, documentation, and the computing environment).
+While a container cannot package all of these blocks, it represents a human- _and_ machine-readable recipe to capture the computing environment and interact with data.
 By providing this recipe, authors of scientific articles greatly improve their work's level of documentation, transparency, and reusability.
 Such practice is one important part of common practices for scientific computing [@wilson_best_2014; @wilson_good_2017], with the result that it is much more likely both the author and others are able to reproduce and extend an analysis workflow.
 The containers built from these recipes are portable encapsulated snapshots of a specific computing environment.
@@ -79,7 +80,10 @@ This article introduces these instructions for the popular `Dockerfile` format w
 # Prerequisites & scope
 
 To start with, we assume you have a scripted scientific workflow, i.e. you can, at least at a certain point in time, execute the full process with a fixed set of commands, for example `make prepare_data` followed by `Rscript analysis.R`, or only `python3 my-workflow.py`.
-Since containers that you eventually share with others can only run open source software, tools like Mathematica and Matlab are out of scope for this example. A workflow that does not support scripted execution is also out of scope for reproducible research, as it does not fit well with containerization. Furthermore, workflows interacting with many petabytes of data and executed in high-performance computing (HPC) infrastructures are out of scope. Using such HPC job managers or cloud infrastructures would require a collection of "Ten Simple Rules" articles in their own right.
+Since containers that you eventually share with others can only run open source software, tools like Mathematica and Matlab are out of scope for this example.
+A workflow that does not support scripted execution is also out of scope for reproducible research, as it does not fit well with containerization.
+Furthermore, workflows interacting with many petabytes of data and executed in high-performance computing (HPC) infrastructures are out of scope.
+Using such HPC job managers or cloud infrastructures would require a collection of "Ten Simple Rules" articles in their own right.
 For this article, we focus on workflows that typically run on single machine, e.g., a researchers laptop computer or a virtual server.
 The reader might scope the data requirement to less than a terabyte, and compute requirement to a machine with 16 cores running over the weekend.
 
@@ -635,7 +639,7 @@ You should prioritize this usage over others, e.g., non-interactive execution of
 
 Second, for reproducibility, we can treat containers as transient and disposable, and even intentionally rebuild an image at regular intervals.
 Ideally, containers that we built years ago should rebuild seamlessly, but this is not necessarily the case, especially with rapidly changing technology relevant to machine learning and data science. 
-A habitual deletion of a container and cache-less rebuild of the image (a) increases security due to updating underlying software, (b) helps to reveals issues requiring manual interference, i.e., changes to code or configuration not documented in the `Dockerfile` but perhaps should be, and (c) allows you to more incrementally debug issues.
+A habitual deletion of a container and cache-less rebuild of the image (a) increases security due to updating underlying software, (b) helps to reveal issues requiring manual interference, i.e., changes to code or configuration not documented in the `Dockerfile` but perhaps should be, and (c) allows you to more incrementally debug issues.
 This habit can be supported by using continuous deployment or CI strategies.
 
 In the case of needing setup or configuration for the first two habits, it is good practice to provide a `Makefile` alongside your container, which can capture the specific commands.

--- a/ten-simple-rules-dockerfiles.tex
+++ b/ten-simple-rules-dockerfiles.tex
@@ -238,7 +238,7 @@
 % Title must be 250 characters or less.
 \begin{flushleft}
 {\Large
-\textbf\newline{Ten Simple Rules for Writing Dockerfiles for Reproducible Research} % Please use "sentence case" for title and headings (capitalize only the first word in a title (or heading), the first word in a subtitle (or subheading), and any proper nouns).
+\textbf\newline{Ten Simple Rules for Writing Dockerfiles for Reproducible Data Science} % Please use "sentence case" for title and headings (capitalize only the first word in a title (or heading), the first word in a subtitle (or subheading), and any proper nouns).
 }
 \newline
 % Insert author names, affiliations and corresponding author email (do not include titles, positions, or degrees).
@@ -284,33 +284,26 @@ workflow.
 
 Computing infrastructure has advanced to the point where not only can we
 share data underlying resarch articles, we can share the code that
-processes these data. The sharing of code files is enabled by
+processes these data. This sharing of code files is enabled by
 collaboration platforms such as \href{https://github.com}{GitHub} or
 \href{https://gitlab.com}{GitLab} and has become quite common. The
-sharing of the computing environment is enabled by containerisation, but
-this possibility is not widely used yet. Containerisation allows for
-documenting and sharing entire workflows in a comprehensive way, which
-is desperately needed to increase reproducibility of computational
-resarch. Computational research is oftentimes way too complicated for
-``papers'' based on the traditional journal article format to fully
-communicate the details of research {[}1{]}, but where the actual
-contribution to knowledge includes the full computing environment that
-produced a result {[}2{]}.
+sharing of the computing environment, on the other hand, is enabled by
+containerization, which allows for documenting and sharing entire
+workflows in a comprehensive way. This sharing of computational assets
+is paramount to increase reproducibility of computational resarch. While
+``papers'' based on the traditional journal article format can share
+high level details of research, computational research is oftentimes way
+too complicated to be disseminated alongside in this format {[}1{]}. In
+that the actual contribution to knowledge includes the full computing
+environment that produced a result, containerization is needed {[}2{]}.
 
-A solution for packaging the building blocks of computer-based research,
-i.e.~code, data, documentation, and the computing environment, is the
-\emph{research compendium}
-(cf.~\url{https://research-compendium.science}). A research compendium
-greatly improves the transparancy and reproducibility of our research,
-because we not only publish abstract algorithms and study designs, but
-also the instructions for recreating and executing whole research
-workflows. Within a research compendium, it is desirable to include
-instructions, i.e.~a human- \emph{and} machine-readable recipe, for
-building containers that capture the computing environment. The
-computing environment comprises all software and data dependencies, as
-these are not captured by the the typical workflow script or
-documentation in a README. By providing this recipe, authors of
-scientific articles greatly improve their work's level of documentation,
+Containerization plays an important role in providing instructions for
+packaging the building blocks of computer-based research (i.e.~code,
+data, documentation, and the computing environment). While a container
+cannot package all of these blocks, it represents a human- \emph{and}
+machine-readable recipe to capture the computing environment and
+interact with data. By providing this recipe, authors of scientific
+articles greatly improve their work's level of documentation,
 transparency, and reusability. Such practice is one important part of
 common practices for scientific computing {[}3,4{]}, with the result
 that it is much more likely both the author and others are able to
@@ -318,18 +311,12 @@ reproduce and extend an analysis workflow. The containers built from
 these recipes are portable encapsulated snapshots of a specific
 computing environment. Such containers have been demonstrated for
 capturing scientific notebooks {[}5{]} and reproducible workflows
-{[}6{]}. Research compendia also allow for proper citation of the used
-computing environment, which is not possible within containers alone.
-Best practices are still a work in progress {[}7{]}, but you should try
-your best to give credit to creators of software you rely on by
-following recommendations of projects such as CodeMeta
-(\url{https://codemeta.github.io/}) and the Citation File Format
-(\url{https://citation-file-format.github.io/}).
+{[}6{]}.
 
 While there are several tutorials for using containers for reproducible
-research {[}8--12{]}, there is no detailed \emph{manual for how to write
+research {[}7--11{]}, there is no detailed \emph{manual for how to write
 the actual instructions to create the containers for computational
-research} besides generic best practices {[}13{]}. This article
+research} besides generic best practices {[}12{]}. This article
 introduces these instructions for the popular \texttt{Dockerfile} format
 with a focus on containers encapsulating data science workflows.
 
@@ -340,65 +327,54 @@ To start with, we assume you have a scripted scientific workflow,
 i.e.~you can, at least at a certain point in time, execute the full
 process with a fixed set of commands, for example
 \texttt{make\ prepare\_data} followed by \texttt{Rscript\ analysis.R},
-or only \texttt{python3\ my-workflow.py}. If you have an ordered set of
-commands building upon each other, you can write a main script that does
-just that, even if you in your daily work might not do that to save
-time. A key constraint is that containers you eventually share with
-others as part of a research compendium can only run open source
-software. Therefore tools like Mathematica and Matlab are out of scope
-of this work. This execution should be able to be triggered by
-command-line instruction, which is possible for all generic programming
-languages and widely used workflow tools, including tools primarily used
-interactively and/or with a graphical user interface. A workflow that
-does not support scripted execution is out of scope for reproducible
-research, and does not fit well with containerisation.
+or only \texttt{python3\ my-workflow.py}. Since containers that you
+eventually share with others can only run open source software, tools
+like Mathematica and Matlab are out of scope for this example. A
+workflow that does not support scripted execution is also out of scope
+for reproducible research, as it does not fit well with
+containerization. Furthermore, workflows interacting with many petabytes
+of data and executed in high-performance computing (HPC) infrastructures
+are out of scope. Using such HPC job managers or cloud infrastructures
+would require a collection of ``Ten Simple Rules'' articles in their own
+right. For this article, we focus on workflows that typically run on
+single machine, e.g., a researchers laptop computer or a virtual server.
+The reader might scope the data requirement to less than a terabyte, and
+compute requirement to a machine with 16 cores running over the weekend.
 
-Furthermore, workflows interacting with many petabytes of data and
-executed in high-performance computing (HPC) infrastructures are out of
-scope. While containers \emph{can} be helpful for analysing data at
-scale, the complexity of theses pipelines, e.g., using HPC job managers
-or cloud infrastructures, requires a collection of ``Ten Simple Rules''
-articles in their own right. Instead, we focus on workflows that
-typically run on single machine, e.g., a researchers laptop computer or
-a virtual server, though they may take some time and resources to
-execute, such as a terabyte of data and 16 cores running over the
-weekend.
-
-In the case of more complex applications that require multiple
-applications, e.g., web servers, databases, and worker containers, it
-might be better to have a \emph{set of containers} using
-\texttt{docker-compose} {[}14{]}. A \texttt{docker-compose.yml}
-configuration file allows for defining volumes, environment variables,
-and exposed ports and helps to stick to \emph{one purpose per
-container}, which often means one process running in the container, and
-to combine existing stable building blocks instead of bespoke massive
-containers for specific purposes. Using \texttt{docker-compose} for a
-data science workflow is out of scope for this article.
+While out of scope for this article, we point the reader to
+\texttt{docker-compose} {[}13{]} in the case of needing container
+orchestration for multiple applications, e.g., web servers, databases,
+and worker containers. A \texttt{docker-compose.yml} configuration file
+allows for defining volumes, environment variables, and exposed ports
+and helps to stick to \emph{one purpose per container}, which often
+means one process running in the container, and to combine existing
+stable building blocks instead of bespoke massive containers for
+specific purposes.
 
 Because \emph{``the number of unique research environments approximates
-the number of researchers''} {[}15{]}, sticking to conventions helps
+the number of researchers''} {[}14{]}, sticking to conventions helps
 every researcher to understand, modify, and eventually write container
 recipes suitable for their needs. Even if they are not sure how the
-technology behind them actually works, reserachers can leverage
-containerisation, but should craft their own definition of computing
-environments following good practices, which are provided here. These
-practices are strongly related to software engineering in general and
-research software engineering (RSEng) in particlar, which is concerned
-with quality, training, and recognition of software in science {[}16{]}.
-Research Software Engineers (RSEs) are not the target audience for this
-work, but we want to encourage you to reach out to your local or
-national RSE community if your needs go beyond the rules of this work.
+technology behind them actually works, researchers should leverage
+containerization following good practices. The practices that are to be
+discussed in this article are strongly related to software engineering
+in general and research software engineering (RSEng) in particlar, which
+is concerned with quality, training, and recognition of software in
+science {[}15{]}. Research Software Engineers (RSEs) are not the target
+audience for this work, but we want to encourage you to reach out to
+your local or national RSE community if your needs go beyond the rules
+of this work.
 
 While there are many different container technologies, this article
-focuses on Docker {[}17{]}. Docker is a highly suitable tool for
-reproducible research (e.g., {[}18{]}) and our observations indicate it
+focuses on Docker {[}16{]}. Docker is a highly suitable tool for
+reproducible research (e.g., {[}17{]}) and our observations indicate it
 is the most widely used container technology in academic data science.
 The goal of this article is to guide you to write a \texttt{Dockerfile},
 which is a file format for creating container images. The rules help you
 to ensure the \texttt{Dockerfile} allows for interactive development as
 well as the higher goals of reproducibility and preservation of
 knowledge. Such practices are generally not part of generic
-containerisation tutorials and are rarely found in \texttt{Dockerfile}s
+containerization tutorials and are rarely found in \texttt{Dockerfile}s
 published as part of software projects, which are often used as
 templates by novices. The differences between a helpful, stable
 \texttt{Dockerfile} and one that is misleading, prone to failure, and
@@ -409,37 +385,37 @@ are reproducible and reusable, that computing environments are
 understandable by others, and researchers can collaborate effectively.
 Their application should not be triggered by the publication of a
 finished project, but be weaved into day-to-day habits (cf.~thoughts on
-openness as an afterthought by {[}19{]} and on computational
+openness as an afterthought by {[}18{]} and on computational
 reproducibility by {[}2{]}).
 
 \hypertarget{docker-dockerfiles}{%
 \section{Docker \& Dockerfiles}\label{docker-dockerfiles}}
 
-Docker {[}17{]} is a container technology that is widely adopted and
+Docker {[}16{]} is a container technology that is widely adopted and
 supported on many platforms, and has become highly useful for research.
 Containers are distinct from virtual machines (VM) or hypervisors as
 they do not emulate hardware or operating system kernels, and thus do
 not require the same system resources. Several platforms for
 facilitating reproducible research are built on top of containers
-{[}15,20--23{]}, but they intentionally hide most of the complexity from
+{[}14,19--22{]}, but they intentionally hide most of the complexity from
 the researcher.
 
 To create Docker containers for specific workflows, we write text files
-that follow a particular format called \texttt{Dockerfile} {[}24{]}.
+that follow a particular format called \texttt{Dockerfile} {[}23{]}.
 \texttt{Dockerfile}s are machine- and human-readable recipes for
-building images. Images are inert, immutable, read-only files that
-include the application, e.g., the programming language interpreter
-needed to run a workflow, and the system libraries required by an
-application to run. A \texttt{Dockerfile} consists of a sequence of
-instructions to copy files and install software. Each instructions adds
-a layers to the image, which can be cached across image builds and
-platforms for minimizing build and download times. The images have a
-main executable that is started when they are run as stateful
-containers, which are the running instances of Docker images. Containers
-can be modified, stopped, restarted and purged. \texttt{Dockerfiles},
-like Makefiles {[}25{]}, are meant to be useful for both humans to read
-and for computers to execute. See Listing~1 for a full
-\texttt{Dockerfile}, which we will refer to throughout this article.
+building images. Container images include the application, e.g., the
+programming language interpreter needed to run a workflow, and the
+system libraries required by an application to run. A
+\texttt{Dockerfile} consists of a sequence of instructions to copy files
+and install software. Each instruction adds a layer to the image, which
+can be cached across image builds and platforms for minimizing build and
+download times. The images have a main executable exposed as an
+``entrypoint'' that is started when they are run as stateful containers,
+which are the running instances of Docker images. Containers can be
+modified, stopped, restarted and purged. \texttt{Dockerfile}s, like
+Makefiles {[}24{]}, are meant to be useful for both humans to read and
+for computers to execute. See Listing~1 for a full \texttt{Dockerfile},
+which we will refer to throughout this article.
 
 While Docker was the original technology to support the
 \texttt{Dockerfile} format, other container technologies with support
@@ -449,19 +425,19 @@ supported by RedHat,
 \href{https://github.com/GoogleContainerTools/kaniko}{kaniko},
 \href{https://github.com/genuinetools/img}{img}, and
 \href{https://github.com/moby/buildkit}{buildkit}. The Singularity
-container software {[}26{]} is optimised for high performance computing
+container software {[}25{]} is optimised for high performance computing
 and although it uses its own format, the \emph{Singularity recipe}, it
 can import and run Docker images. Although the Singularity recipe format
 is different, the rules here are transferable to some extent. While some
 may argue for reasons to not publish reproducibly, e.g., lack of time
-and incentives, reluctance to share (cf.~{[}27{]}) and there are
+and incentives, reluctance to share (cf. {[}26{]}) and there are
 substantial technical challenges to maintain software and documentation,
 providing a \texttt{Dockerfile}, a pre-built Docker image, or other type
 of container should become an increasingly easier task for the average
 researcher. If a researcher is able to find and create containers or
 write a \texttt{Dockerfile} to address their most common use cases, then
 arguably it will not be extra work after this initial set up (cf.~README
-of {[}28{]}). In fact, the \texttt{Dockerfile} itself can be a powerful
+of {[}27{]}). In fact, the \texttt{Dockerfile} itself can be a powerful
 documentation to show from where data and code was derived,
 i.e.~downloaded or installed, and consequently where a third party might
 obtain them again.
@@ -543,21 +519,22 @@ documentation instructions for doing so. As an example, you might be
 doing some kind of interactive development. For interactive development
 environments such as notebooks and development servers or databases, you
 can readily find containers that come installed with all the software
-that you need. You look for information about images (a) in the
+that you need. You can look for information about images in (a) the
 documentation of the used software, (b) the Docker image registry
-\emph{Docker Hub}, \url{https://hub.docker.com/}, or (c) in the source
-code projects of the used software, as many developers today rely on
+\emph{Docker Hub}, \url{https://hub.docker.com/}, or (c) the source code
+projects of the used software, as many developers today rely on
 containers for development, testing, and teaching.
 
 Second, in the case that there isn't an existing container for your
 needs, you might next look to well-maintained tools to help with
 \texttt{Dockerfile} generation. These tools can add required software
 packages to an existing image without you having to manually write a
-\texttt{Dockerfile} at all. ``Well-maintained'' includes the tool's own
-stability and usability, but also that suitable base images are used,
-likely from the official Docker library {[}29{]}, to ensure that the
-container has the most recent security fixes for the operating system in
-question. See below box ``Tools for container generation'' for details.
+\texttt{Dockerfile} at all. ``Well-maintained'' references the tool's
+own stability and usability, but also that suitable base images are
+used, likely from the official Docker library {[}28{]}, to ensure that
+the container has the most recent security fixes for the operating
+system in question. See below box ``Tools for container generation'' for
+details.
 
 Third, you may want to write you own \texttt{Dockerfile} if these tools
 do not suffice for your needs. \emph{In this case, follow the remaining
@@ -569,7 +546,7 @@ rules.}
 \subsection{Tools for container
 generation}\label{tools-for-container-generation}}
 
-Repo2docker {[}23{]} is a tool that is maintained by
+Repo2docker {[}22{]} is a tool that is maintained by
 \href{https://jupyter.org/}{Project Jupyter} that can help to transform
 a source code or data repository, e.g.~GitHub, GitLab, or Zenodo, into a
 container. The tool relies on common configuration files for defining
@@ -593,7 +570,7 @@ requirements file, along with providing an entrypoint to run a notebook
 server to interact with any existing workflows in the repository. Since
 repo2docker is used within \href{https://mybinder.org/}{MyBinder.org},
 if you make sure your workflow is ``Binder-ready'', you and others can
-also get an online workspace with a single click.` A precaution that
+also get an online workspace with a single click. A precaution that
 needs to be taken is that the default command above will create a home
 for the current user, meaning that the container itself would not be
 ideal to share, but rather any researchers interested in interaction
@@ -604,7 +581,7 @@ are the same
 ensuring the same software versions).
 
 Additional tools to assist with writing \texttt{Dockerfile}s include
-\texttt{containerit} {[}30{]} and \texttt{dockta} {[}31{]}.
+\texttt{containerit} {[}29{]} and \texttt{dockta} {[}30{]}.
 \texttt{containerit} automates the generation of standalone
 \texttt{Dockerfile}s for workflows in R. It can provide a starting point
 for users unfamiliar with writing \texttt{Dockerfile}s, or together with
@@ -613,7 +590,10 @@ without having to leave an R session. \texttt{dockta} supports multiple
 programming languages and configurations files, just as
 \texttt{repo2docker}, but attempts to create readable
 \texttt{Dockerfile}s compatible with plain Docker and to improve user
-experience by cleverly adjusting instructions to reduce build time.
+experience by cleverly adjusting instructions to reduce build time. For
+any tool that you use, be sure to look at documentation for usage and
+configuration options, and options to add metadata (e.g., labels
+see~\hyperref[{rule:metadata}]{Rule~\ztitleref{rule:metadata}}).
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
@@ -626,51 +606,54 @@ experience by cleverly adjusting instructions to reduce build time.
 A good understanding of how base images and image tags work is crucial,
 as the image and tag that you choose has important implications for your
 container. It's good practice to use base images that are maintained by
-the Docker library, so called \emph{``official images''} {[}32{]}, which
+the Docker library, so called \emph{``official images''} {[}31{]}, which
 benefit from a review for best practices and vulnerability scanning
-{[}13{]}. You can identify these images by the missing the user portion
+{[}12{]}. You can identify these images by the missing the user portion
 of the image name, which comes before the \texttt{/}, e.g.,
 \texttt{r-base} or \texttt{python}. However, these images only provide
-basic programming languages or very widely used software. So you will
-likely use images maintained by organisations or fellow researchers.
-While some organisations can be trusted to update containers with
+basic programming languages or very widely used software, so you will
+likely use images maintained by organizations or fellow researchers.
+While some organizations can be trusted to update containers with
 security fixes (see list below), for most individual accounts that
 provide ready to use images, it is likely that these will not be updated
 regularly. It is even possible that images or \texttt{Dockerfile}s may
 disappear, or that images are published with malicious intent, though we
 have not heard of any such case in academia. Therefore, for security,
 transparency, and reproducibility, you should only use images where you
-have access to the \texttt{Dockerfile}. Do save a copy of the
-\texttt{Dockerfile}, e.g., by cloning the public repository where the
-\texttt{Dockerfile}s are maintained.
+have access to the \texttt{Dockerfile}, and it is suggested to save a
+copy of the \texttt{Dockerfile} in the case that a repository or other
+distribution goes away.
 
 Images have \emph{tags} associated with them with specific meanings,
-e.g., a version indicator such as \texttt{1.2} or \texttt{dev}, or
+e.g., a version indicator such as \texttt{3.7} or \texttt{dev}, or
 variants such as \texttt{slim} attempting to reduce image size. Tags are
 defined at image built time and appear in image name after the
-\texttt{:} when you use an image, e.g., \texttt{python:1.2}. By
+\texttt{:} when you use an image, e.g., \texttt{python:3.7}. By
 \emph{convention} a missing tag is assumed to be the word
 \texttt{latest}, which gives you the latest updates but also a moving
 target for your computing environment that can break your workflow. Note
 that a version tag means that the tagged software is frozen, but it does
 not mean the image will not change, as backwards compatible fixes
-(cf.~semantic versioning, {[}33{]}), e.g., version \texttt{1.2.3} fixing
+(cf.~semantic versioning, {[}32{]}), e.g., version \texttt{1.2.3} fixing
 a security problem in version \texttt{1.2.2} or updates to an underlying
-system library, will still be included.
+system library, would be published to the parent tag \texttt{1.2}.
 
 For data science workflows, you should always rely on version-specific
 image tags both for base images that you use, and for images that you
-build yourself and then run. Also do not worry about image size, because
-the size will be often be much smaller than the data anyway. It is good
-practice to publish an image in an image registry, and we refer you to
-the documentation on automated builds for details, see
+build yourself and then run. With keeping different versions (tags)
+available, it is good practice to publish an image in an image registry.
+We refer you to the documentation on automated builds for details, see
 \href{https://docs.docker.com/docker-hub/builds/}{Docker Hub Builds} or
 \href{https://docs.gitlab.com/ee/user/packages/container_registry/index.html\#build-and-push-images}{GitLab's
-Container Registry}. Do not \texttt{docker\ push} a locally built image,
-because that counteracts the considerations outlined above. If a
-pre-built image is provided in a public image registry, do not forget to
-direct the user to it in your documentation, e.g.~in the \texttt{README}
-file or in an article.
+Container Registry} as well as CI platforms such as
+\href{https://github.com/actions/starter-workflows/tree/master/ci}{GitHub
+actions}, or
+\href{https://circleci.com/orbs/registry/orb/circleci/docker\#commands-build}{CircleCI}
+that can help you get started. Do not \texttt{docker\ push} a locally
+built image, because that counteracts the considerations outlined above.
+If a pre-built image is provided in a public image registry, do not
+forget to direct the user to it in your documentation, e.g.~in the
+\texttt{README} file or in an article.
 
 The following list a selection of communities that produce widely used
 regularly updated images, including ready-to-use images with
@@ -684,13 +667,13 @@ library.
 \tightlist
 \item
   \href{https://www.rocker-project.org/}{Rocker} for R and RStudio
-  images {[}18{]}
+  images {[}17{]}
 \item
   \href{https://bioconductor.org/help/docker/}{Bioconductor Docker
   images} for bioinformatics with R
 \item
   \href{https://hub.docker.com/_/neurodebian}{NeuroDebian images} for
-  neuroscience {[}34{]}
+  neuroscience {[}33{]}
 \item
   \href{https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html}{Jupyter
   Docker Stacks} for Notebook-based computing
@@ -700,17 +683,17 @@ library.
 \end{itemize}
 
 For example, here is how we would use a base image \texttt{verse}, which
-provides the populary Tidyverse suite of packages {[}35{]}, with R
-version \texttt{3.5.2} from the \texttt{rocker} organisation on Docker
+provides the populary Tidyverse suite of packages {[}34{]}, with R
+version \texttt{3.5.2} from the \texttt{rocker} organization on Docker
 Hub (\texttt{docker.io}, which is the default and can be omitted).
 
 \begin{verbatim}
 FROM docker.io/rocker/r-ver:3.5.2
 \end{verbatim}
 
-\hypertarget{fomat-intentionally-and-favour-clarity}{%
-\section{3. Fomat intentionally and favour
-clarity}\label{fomat-intentionally-and-favour-clarity}}
+\hypertarget{format-intentionally-and-favor-clarity}{%
+\section{3. Format intentionally and favor
+clarity}\label{format-intentionally-and-favor-clarity}}
 
 \ztitlerefsetup{title=3} \zlabel{rule:formatting} \label{rule:formatting} \zrefused{rule:formatting}
 \ztitlerefsetup{title=3} \zlabel{rule:clarity} \label{rule:clarity} \zrefused{rule:clarity}
@@ -737,12 +720,13 @@ small image size, you should keep the script in the container for a
 future user to inspect. A common pattern you might encounter is a single
 \texttt{RUN} instruction that updates the database of available
 packages, installs a software from a package repository, and then purges
-the cache of the package manager. For Depending on the programming
-language used, your project may already contain files to manage
-dependencies and you may use a package manager to control this aspect of
-the computing environment. This is a very good practice and helpful,
-though you should consider the externalisation of content to outside of
-the \texttt{Dockerfile} (see
+the cache of the package manager.
+
+Depending on the programming language used, your project may already
+contain files to manage dependencies and you may use a package manager
+to control this aspect of the computing environment. This is a very good
+practice and helpful, though you should consider the externalization of
+content to outside of the \texttt{Dockerfile} (see
 \hyperref[{rule:mount}]{Rule~\ztitleref{rule:mount}}). A single long
 \texttt{Dockerfile} with sections and helpful comments can be complete
 and thus more understandable than a collection of separate files.
@@ -752,19 +736,15 @@ performs one scoped action, e.g., download, compile, and install
 \emph{one tool}. Each instruction will result in a new layer, and
 reasonably grouped changes increase readability of the
 \texttt{Dockerfile} and facilitate inspection of the image, e.g., with
-tools like dive {[}36{]}. Convoluted \texttt{RUN} instructions can be
+tools like dive {[}35{]}. Convoluted \texttt{RUN} instructions can be
 acceptable to reduce the number of layers, but careful layout and
 consistent formatting should be applied (see
-\hyperref[{rule:formatting}]{Rule~\ztitleref{rule:formatting}}). A
-\texttt{RUN} instruction not fully visible on your screen requires
-scrolling and thereby diminishes readability. This may be challenging
-for the next reader to digest and you should consider splitting it up,
-accepting the extra layers added to the image.
+\hyperref[{rule:formatting}]{Rule~\ztitleref{rule:formatting}}).
 
 While you will find \texttt{Dockerfile}s using
 \href{https://docs.docker.com/engine/reference/commandline/build/\#set-build-time-variables---build-arg}{\emph{build-time
 variables}} to dynamically change parameters at build time, such a
-customisation option reduces clarity for data science workflows based on
+customization option reduces clarity for data science workflows based on
 research compendia.
 
 \hypertarget{document-within-the-dockerfile}{%
@@ -777,23 +757,23 @@ Dockerfile}\label{document-within-the-dockerfile}}
 \subsection{Comments}\label{comments}}
 
 As you are writing the \texttt{Dockerfile}, be mindful of how other
-people will read it and why. Are your choices and commands being
-executed clear, or is further comment warranted? To assist others in
-making sense of your \texttt{Dockerfile}, you can add comments that
-include links to online forums, code repository issues, or VCS commit
-messages to give context for your specific decisions. For example
+people (including future you!) will read it and why. Are your choices
+and commands being executed clearly, or is further comment warranted? To
+assist others in making sense of your \texttt{Dockerfile}, you can add
+comments that include links to online forums, code repository issues, or
+version control commit messages to give context for your specific
+decisions. For example
 \href{https://github.com/Kaggle/docker-rstats/blob/master/Dockerfile}{this
 \texttt{Dockerfile} by Kaggle} does a good job at explainig the
-reasoning and steps of the contained instructions. Comments should
-include helpful usage guides and links for readers inspecting the
-\texttt{Dockerfile}, including future you. For example, if you copy
+reasoning and steps of the contained instructions. If you copy
 instructions from another \texttt{Dockerfile}, acknowledge the source in
 a comment. It can even be helpful to include comments about commands
 that did not work so you do not repeat past mistakes. If you find that
 you need to remember an undocumented step, that is an indication that it
 should be documented in the \texttt{Dockerfile}. All instructions can be
 grouped starting with a short comment, which also makes it easier to
-spot changes if your \texttt{Dockerfile} is managed in a VCS (see
+spot changes if your \texttt{Dockerfile} is managed in some version
+control system (see
 \hyperref[{rule:publish}]{Rule~\ztitleref{rule:publish}}).
 
 Here is a selection of typical kinds of comments that are useful to
@@ -835,15 +815,14 @@ versions, license, and maintainer contact information are commonly seen
 and very useful if a \texttt{Dockerfile} is discovered out of context.
 While you can add arbitrarily complex information with labels, for
 research compendia the user-facing documentation is much more important.
-If you want to earn extra points, and you never know what future
-algorithms will be able to make sense of, include global identifiers
-such as \href{https://orcid.org/}{ORCID identifiers} for people, a DOI
-of the research compendium, e.g.,
-\href{https://help.zenodo.org/}{reserved on Zenodo} before publishing
-the research compendium, or your funding agency's grant number.
+Important metadata that might be more utilized with future tools
+includes global identifiers such as \href{https://orcid.org/}{ORCID
+identifiers}, DOIs of the research compendium, e.g.,
+\href{https://help.zenodo.org/}{reserved on Zenodo}, or a funding
+agency's grant number.
 
 The OCI Image Format Specification provides some common label keys (see
-the ``Annotations'' section in {[}37{]}) to help standardise field names
+the ``Annotations'' section in {[}36{]}) to help standardise field names
 across container tools, as shown below. These labels match the
 \href{http://label-schema.org/rc1/}{\texttt{org.label-schema}-specification},
 which has been deprecated but is still found a lot in
@@ -879,29 +858,18 @@ org.label-schema.docker.schema-version=``rc1'' ```
 
 It is often helpful to provide usage instructions, i.e., how to
 \texttt{docker\ build} and \texttt{docker\ run} the image, \emph{within}
-the \texttt{Dockerfile}. Such documentation is especially relevant if
-volume mounts or ports are important for using the container, see for
-example the final lines of Listing~1. By putting the usage documentation
-at the end of the file, they are easy to copy-paste after a container
-build when you are likely to have the \texttt{Dockerfile} open, and,
-most importantly, they can be kept in consistent state compared to
-documentation in another file. This helps both you and others. It helps
-you when you pick up a previously written \texttt{Dockerfile} and for
-example do not remember the container identifier you used, it would be
-represented in the \texttt{Dockerfile} in the \texttt{-\/-name}
-parameter, preserved in a comment. Following a common coding aphorism,
-we might say \emph{``A Dockerfile written three months ago may just as
-well have been written by someone else''}. It helps others, because it
-quickly gets them running your workflow and interacting with the
-container in the intended way without reading all of the instructions (a
+the \texttt{Dockerfile}, either at the top or bottom where the reader is
+likely to find it. Such documentation is especially relevant if volume
+mounts, specific names, or ports are important for using the container,
+see for example the final lines of Listing~1. Following a common coding
+aphorism, we might say \emph{``A Dockerfile written three months ago may
+just as well have been written by someone else''}. It helps others,
+because it quickly gets them running your workflow and interacting with
+the container in the intended way without reading all of the
+instructions (a
 \href{https://en.wikipedia.org/wiki/Wikipedia:Too_long;_didn\%27t_read}{``tl;dr''}-kind
-of usage). Your documentation, e.g.~\texttt{README} file, should not
-duplicate this information alongside the \texttt{Dockerfile} for exactly
-how to build, run, and otherwise interact with the container but instead
-point to the \texttt{Dockerfile}. Duplicate usage instructions with
-eventually diverge and lead to frustration, and referring to the
-\texttt{Dockerfile} has the added advantage that you point your reader
-to it, demonstrating your careful work habits and good intentions for
+of usage). The \texttt{Dockerfile} alongside your documentation strategy
+is a demonstration of your careful work habits and good intentions for
 transparency and computational reproducibility.
 
 \hypertarget{order-instructions}{%
@@ -909,22 +877,22 @@ transparency and computational reproducibility.
 
 \ztitlerefsetup{title=5} \zlabel{rule:order} \label{rule:order} \zrefused{rule:order}
 
-You will regularly build an image more during development of your
-workflow. You can take advantage of \emph{build caching} to avoid
-execution of time-consuming instructions, e.g., install from a remote
-resource or a copying a file that gets cached. Therefore you should add
-instructions \emph{in order} of least likely to change to most likely to
-change. Docker will execute the instructions in the order as they appear
-in the \texttt{Dockerfile}. When one instruction is completed, the
-result is cached, and the build moves to the next one. If you change
-something in the Dockerfile, and rebuild the container, each instruction
-is inspected in turn. If it hasn't changed, the cached layer is used and
-the build progresses. If the line has changed, that build step is
-executed afresh and then every following instruction will have to be
-executed in case the changed line influences a later instruction. You
-should regularly re-build the image using the \texttt{-\/-no-cache}
-option to learn about broken instructions as soon as possible
-(cf.~\hyperref[{rule:usage}]{Rule~\ztitleref{rule:usage}}).¸
+You will regularly build an image during development of your workflow.
+You can take advantage of \emph{build caching} to avoid execution of
+time-consuming instructions, e.g., install from a remote resource or a
+copying a file that gets cached. Therefore you should add instructions
+\emph{in order} of least likely to change to most likely to change.
+Docker will execute the instructions in the order as they appear in the
+\texttt{Dockerfile}. When one instruction is completed, the result is
+cached, and the build moves to the next one. If you change something in
+the Dockerfile, and rebuild the container, each instruction is inspected
+in turn. If it hasn't changed, the cached layer is used and the build
+progresses. If the line has changed, that build step is executed afresh
+and then every following instruction will have to be executed in case
+the changed line influences a later instruction. You should regularly
+re-build the image using the \texttt{-\/-no-cache} option to learn about
+broken instructions as soon as possible (cf.
+\hyperref[{rule:usage}]{Rule~\ztitleref{rule:usage}}).¸
 
 A recommended ordering based on these considerations is as follows.
 
@@ -959,9 +927,9 @@ reproducible builds}
 
 The reproducibility of your \texttt{Dockerfile} heavily depends on how
 well you define the versions of software to be installed in the image.
-The more specific, the better, because using the desired version leads
-to reproducible builds. The practice of specifying versions of software
-is called \emph{version pinning} (e.g., on \texttt{apt}:
+The more specific the better, because using the desired version leads to
+reproducible builds. The practice of specifying versions of software is
+called \emph{version pinning} (e.g., on \texttt{apt}:
 https://blog.backslasher.net/my-pinning-guidelines.html). For stable
 workflows in a scientific context, it is generally advised to freeze the
 computing environment explicitly and not rely on the ``current'' or
@@ -1025,15 +993,15 @@ languages in scientific programming:
 \begin{itemize}
 \tightlist
 \item
-  Python: \texttt{requirements.txt} (pip tool, {[}38{]}),
-  \texttt{environment.yml} (Conda, {[}39{]})
+  Python: \texttt{requirements.txt} (pip tool, {[}37{]}),
+  \texttt{environment.yml} (Conda, {[}38{]})
 \item
-  R: \texttt{DESCRIPTION} file format {[}40{]} and \texttt{r} (``little
-  R'', {[}41{]})
+  R: \texttt{DESCRIPTION} file format {[}39{]} and \texttt{r} (``little
+  R'', {[}40{]})
 \item
-  JavaScript: \texttt{package.json} of \texttt{npm} {[}42{]}
+  JavaScript: \texttt{package.json} of \texttt{npm} {[}41{]}
 \item
-  Julia: \texttt{Project.toml} and \texttt{Manifest.toml} {[}43{]}
+  Julia: \texttt{Project.toml} and \texttt{Manifest.toml} {[}42{]}
 \end{itemize}
 
 In some cases (e.g., Conda) the package manager is also able to make
@@ -1061,10 +1029,10 @@ serves as more clear documentation in a \texttt{Dockerfile} than a
 \end{Highlighting}
 \end{Shaded}
 
-This modularisation is a potential risk for understandability and
+This modularization is a potential risk for understandability and
 consistency, which can be mitigated by carefully managing all these
 files in the same version-controlled project. You can also use package
-manager to install software from source code \texttt{COPY}ied into the
+managers to install software from source code \texttt{COPY}ied into the
 image (see~\hyperref[{rule:mount}]{Rule~\ztitleref{rule:mount}}). And
 finally, you can use many package managers to install software from
 source obtained from code management repositories, e.g., installing a
@@ -1083,7 +1051,7 @@ instruction} in a \texttt{Dockerfile} and how your base image might
 adjust the user to enable particular usages. It is common to use images
 with the default user \texttt{root}, e.g., , \texttt{root} is required
 for installing system dependencies. We recommend to make sure the image
-works without specifying a users, and to document precisely if your
+works without specifying any users, and to document precisely if your
 image deviates from that. One reason you will encounter base images
 running a non-root user (popular examples are the Jupyter and Rocker
 image stacks) is to avoid permission problems when mounting files into
@@ -1098,20 +1066,20 @@ data}\label{mount-user-scripts-and-data}}
 \ztitlerefsetup{title=7} \zlabel{rule:mount} \label{rule:mount} \zrefused{rule:mount}
 
 The role of containers is to provide the computing environment, not to
-encapsulate datasets or control scripts. It is better to insert data
-files and scripts files from the local machine into the container at run
-time, and using the container image primarily for the software and
-dependencies. This insertion is achieved by using
+encapsulate datasets or custom scripts. It is better to insert data
+files and custom scripts files from the local machine into the container
+at run time, and using the container image primarily for the software
+and dependencies. This insertion is achieved by using
 \href{https://docs.docker.com/storage/bind-mounts/}{\emph{bind mounts}}.
 Mounting these files is preferable to using the
 \texttt{ADD}/\texttt{COPY} instructions in the \texttt{Dockerfile},
 because files persist when the container instance or image is removed
 from your system, and the files are more accessible when the workspace
-is published as a research compendium. If you want to add local files to
-the container, prefer \texttt{COPY} because it is explicit and you do
-not need \texttt{ADD}'s extra features, which are (i) URL as a source,
-for which you may use it instead of a \texttt{RUN\ wget} or
-\texttt{RUN\ curl} to download files, and (ii) a local
+is published. If you want to add local files to the container, prefer
+\texttt{COPY} because it is explicit and you do not need \texttt{ADD}'s
+extra features, which are (i) URL as a source, for which you may use it
+instead of a \texttt{RUN\ wget} or \texttt{RUN\ curl} to download files,
+and (ii) a local
 \href{https://en.wikipedia.org/wiki/Tar_(computing)}{tar file} as a
 source, which you should avoid because such an archive file will be
 harder for future readers of your \texttt{Dockerfile} to make sense of
@@ -1142,20 +1110,20 @@ proprietary data or private information. Do not include such data in an
 image. To avoid publishing sensitive data by accident, you can add the
 data directory to the
 \href{https://docs.docker.com/engine/reference/commandline/build/\#use-a-dockerignore-file}{\texttt{.dockerignore}}
-file, which excludes files and directories from the
+file that excludes files and directories from the
 \href{https://docs.docker.com/engine/reference/commandline/build/\#extended-description}{build
 context}, i.e., the set of files considered by \texttt{docker\ build}.
 Ignoring data files also speeds up the build in case of very large files
 or many small files, the latter of which makes it common to ignore for
-example the \texttt{.git} folder of the Git VCS. You should include
-dummy or test data into the image to be able to ensure that a container
-is functional without a larger custom dataset, e.g., for automated tests
-or instructions in the user manual. For all these cases you should
-provide clear instructions for users in the \texttt{README} how to
-obtain actual or dummy data. When publishing your workspace, e.g., on
-Zenodo, having data and script contents as regular files outside of the
-container makes them more accessible to others, for example for reuse or
-analysis.
+example the \texttt{.git} folder of the Git version control system. You
+should include dummy or test data into the image to be able to ensure
+that a container is functional without a larger custom dataset, e.g.,
+for automated tests or instructions in the user manual. For all these
+cases you should provide clear instructions for users in the
+\texttt{README} how to obtain actual or dummy data. When publishing your
+workspace, e.g., on Zenodo, having data and script contents as regular
+files outside of the container makes them more accessible to others, for
+example for reuse or analysis.
 
 A mount can can also be used to access \emph{output data} from a
 container. This can be an extra mount, or the same \texttt{data}
@@ -1168,7 +1136,7 @@ users.
 
 You can use the \texttt{-v}/\texttt{-\/-volume} or \texttt{-\/-mount}
 flags to \texttt{docker\ run} to configure bind mounts of directories or
-files {[}44{]}, including options, as shown in the following examples.
+files {[}43{]}, including options, as shown in the following examples.
 If the target path exists within the image, the bind mount will replace
 it for the started container.
 
@@ -1204,7 +1172,7 @@ Containers are very well suited for day-to-day development tasks (see
 also \hyperref[{rule:usage}]{Rule~\ztitleref{rule:usage}}), because they
 support common interactive environments for data science and software
 development. But they are also useful for a ``headless'' execution of a
-full workflows. For example, {[}45{]} demonstrates a container for
+full workflows. For example, {[}44{]} demonstrates a container for
 running an agent-based model with video files as outputs, or this
 article's \href{https://rmarkdown.rstudio.com/}{R Markdown} source,
 which could include cells with analysis code, is
@@ -1214,28 +1182,31 @@ execution may even be seen as irreproducible.
 
 These two usages can be configured by the \texttt{Dockerfile}'s author
 and exposed to the user based on the \texttt{Dockerfile}'s \texttt{CMD}
-and \texttt{ENTRYPOINT} instructions. An images main purpose is
+and \texttt{ENTRYPOINT} instructions. An image's main purpose is
 reflected by the default process and configuration, though the
 \texttt{CMD} and \texttt{ENTRYPOINT} can also be changed at runtime. It
 is considered good practice to have a combination of default command and
 entrypoint that meets reasonable user expectations. For example, a
-container known to be a workflow should execute the workflow, or provide
-instructions for how to do so. Since you are likely the primary user of
-the \texttt{Dockerfile} and image, so you should choose a selection or
-combination that works for you, only then accomodate other user's needs.
-A possible weakness with using containers is the limitation on only
-providing one default command and entrypoint. However tools, e.g., The
-Scientific Filesystem {[}46{]}, have been developed to expose multiple
-entrypoints, environments, help messages, labels, and even install
-sequences. With plain Docker, you can override the defaults as part of
-the \texttt{docker\ run} command or in an extra \texttt{Dockerfile}
-using the primary image as a base, as shown in Listing~2. In any case
-you should document different variants ver well, potentially capture
-build and run commans a \texttt{Makefile} {[}25{]}. To support advanced
-custom configuration, it's helpful to expose settings via a
-configuration file, which can be bind mounted from the host {[}45{]},
-via environment variables {[}47{]}, or via wrappers using Docker, such
-as Kliko {[}48{]}.
+container known to be a workflow should execute the entrypoint to the
+workflow, and perhaps use \texttt{-\/-help} as the command to print out
+usage. The container entrypoint should \emph{not} execute the workflow,
+as the user is likely to run the container for basic inspection, and
+starting an analysis as a surprise that might write files is undesired.
+As the maintainer of the workflow, you should write clear instructions
+for how to properly interact with the container, both for yourself and
+others. A possible weakness with using containers is the limitation on
+only providing one default command and entrypoint. However tools, e.g.,
+The Scientific Filesystem {[}45{]}, have been developed to expose
+multiple entrypoints, environments, help messages, labels, and even
+install sequences. With plain Docker, you can override the defaults as
+part of the \texttt{docker\ run} command or in an extra
+\texttt{Dockerfile} using the primary image as a base, as shown in
+Listing~2. In any case you should document different variants ver well,
+potentially capture build and run commans a \texttt{Makefile} {[}24{]}.
+To support advanced custom configuration, it's helpful to expose
+settings via a configuration file, which can be bind mounted from the
+host {[}44{]}, via environment variables {[}46{]}, or via wrappers using
+Docker, such as Kliko {[}47{]}.
 
 \footnotesize
 
@@ -1299,7 +1270,7 @@ abbreviated).
 \end{verbatim}
 
 A person who is unfamiliar with Docker but wants to use your image may
-rely on graphical tools like Kitematic {[}49{]} or
+rely on graphical tools like Kitematic {[}48{]} or
 \href{https://containds.com/}{ContainDS} for assistance in managing
 containers on their machine without using the Docker CLI.
 
@@ -1309,12 +1280,12 @@ this style of user interface. Running the container will provide a shell
 where a tool can be used and help or error messages can assist the user.
 For example, complex workflows in any programming language can, with
 suitable pre-configuration, be triggered by running a specific script
-file. If your workflow can be executed via a CLI you may use that to
-validate correct functionality of an image in automated builds,
-e.g.~using a small toy example and checking the output, by checking
-successful responses from HTTP endpoints provided by the container,
-e.g.~via an HTTP response code of \texttt{200}, or by using a controller
-such as Selenium {[}50{]}.
+file. If your workflow can be executed via a command line client you may
+use that to validate correct functionality of an image in automated
+builds, e.g.~using a small toy example and checking the output, by
+checking successful responses from HTTP endpoints provided by the
+container, e.g.~via an HTTP response code of \texttt{200}, or by using a
+controller such as Selenium {[}49{]}.
 
 The followig example runs a simple R command counting the lines in this
 articles source file. The file path is passed as an environment
@@ -1342,10 +1313,10 @@ variable.
 If there is only a regular desktop application, the hosts window manager
 can be connected to the container. This has notable security
 implications, which are reduced by using the ``X11 forwarding'' natively
-supported by Singularity {[}51{]}, which can execute Docker containers,
-or by leveraging supporting tools such as \texttt{x11docker} {[}52{]}.
-Bidge containers {[}53{]} and exposing a regular desktop via the browser
-(e.g., for Jupyter Hub {[}54{]}) are further alternatives. This variety
+supported by Singularity {[}50{]}, which can execute Docker containers,
+or by leveraging supporting tools such as \texttt{x11docker} {[}51{]}.
+Bidge containers {[}52{]} and exposing a regular desktop via the browser
+(e.g., for Jupyter Hub {[}53{]}) are further alternatives. This variety
 of approaches render seemingly more convenient uncontainerised
 environments, i.e.~just using the local machine, unneccessary in favour
 of reproducibility and portability.
@@ -1360,22 +1331,19 @@ publish it with a version control system}
 \ztitlerefsetup{title=9} \zlabel{rule:publish} \label{rule:publish} \zrefused{rule:publish}
 
 Because a \texttt{Dockerfile} is a plain text-based format, it works
-well with VCS. Including a \texttt{Dockerfile} alongside your code and
-data in a research compendium is an effective way to consistently build
+well with version control systems. Including a \texttt{Dockerfile}
+alongside your code and data is an effective way to consistently build
 your software, to show visitors to the repository how it is built and
 used, to solicit feedback and collaborate with your peers, and to
-increase the impact and sustainability of your work (cf.~{[}55{]}).
+increase the impact and sustainability of your work (cf. {[}54{]}).
 Online collaboration platforms (e.g., GitHub, GitLab) also make it easy
 to use CI services to test building and executing your image in an
 independent environment. Continuous integration increases stability and
-trust, and gives the ability to publish images automatically. If your
-\texttt{Dockerfile} includes an interactive user interface, you can also
-adapt it so that it is ready-to-use as a Binder instance {[}23{]},
-providing an online work environment to any user with a simple click of
-a link. Furthermore, the commit messages in your version controlled
-repository preserve a record of all changes to the \texttt{Dockerfile}.
+trust, and gives the ability to publish images automatically.
+Furthermore, the commit messages in your version controlled repository
+preserve a record of all changes to the \texttt{Dockerfile}.
 
-While there are exceptions to the rule (cf.~{[}56{]}), it's generally a
+While there are exceptions to the rule (cf.~{[}55{]}), it's generally a
 simple and clear approach to provide one \texttt{Dockerfile} per
 project. Alternatively, you could build an \emph{image stack} to serve
 different use cases with a common base image, but this reduces
@@ -1383,30 +1351,30 @@ understandability and scatters information across multiple places. We
 recommend to avoid this at the price of a longer \texttt{Dockerfile} and
 mitigate with consistent form
 (see~\hyperref[{rule:formatting}]{Rule~\ztitleref{rule:formatting}}).
-Yet most importantly, you should publish \emph{all} files
-\texttt{COPY}ied into the container, e.g., test data or files for
-software installation from source
-(see~\hyperref[{rule:mount}]{Rule~\ztitleref{rule:mount}}), in the same
-research compendium.
+Importantly, you should publish \emph{all} files \texttt{COPY}ied into
+the container, e.g., test data or files for software installation from
+source (see~\hyperref[{rule:mount}]{Rule~\ztitleref{rule:mount}}), in
+the same research compendium.
 
 It is likely going to be the case that over time you will develop
 workflows that are similar in nature to one another. When developing or
 working on projects with containers you can switch between isolated
 project environments by stopping the container and restarting it when
 you are ready to work again, even on another machine or in a cloud
-environment. You can even run projects in parallel without interference.
-In case you feel like constantly repeating yourself, you should consider
-adopting a standard workflow that will give you a clean slate for a new
-project. As an example, cookie cutter templates {[}57{]}, project
-starter kits {[}REF{]}, or community templates (e.g., {[}58{]}) can
-provide required files, e.g., for documention, CI, and licenses, and
-structure for getting started. If you decide to build your own best
-practice, consider to collaborate with your community during development
-of the standard to ensure it will be useful to others. Part of your
-project template should be a protocol for publishing the
-\texttt{Dockerfile} and even an export of the image in a suitable
-location, e.g., a container registry or data repository, taking into
-consideration of how your workflow can receive a DOI for citation.
+environment. You can even run projects in parallel that don't share
+ports without interference. In case you feel like constantly repeating
+yourself, you should consider adopting a standard workflow that will
+give you a clean slate for a new project. As an example, cookie cutter
+templates {[}56{]}, project starter kits {[}REF{]}, or community
+templates (e.g., {[}57{]}) can provide required files, e.g., for
+documention, CI, and licenses, and structure for getting started. If you
+decide to build your own cookie cutter template, consider collaborating
+with your community during development of the standard to ensure it will
+be useful to others. Part of your project template should be a protocol
+for publishing the \texttt{Dockerfile} and even an export of the image
+in a suitable location, e.g., a container registry or data repository,
+taking into consideration of how your workflow can receive a DOI for
+citation.
 
 \hypertarget{use-the-container-daily-rebuild-the-image-weekly-clean-up-and-preserve-if-need-be}{%
 \section*{10. Use the container daily, rebuild the image weekly, clean
@@ -1419,21 +1387,22 @@ image weekly, clean up and preserve if need be}
 
 Using containers for research workflows does not only require technical
 understanding, but also an awareness of risks that can be managed
-efficiently by following a number of good \emph{habits}, which we
-outline below. While there is no firm rule, if you use a container
-daily, is good practice to rebuild that container every once or two
-weeks. At the time of publication of research results it is good
-practice to save a copy of the image in a public data repository so that
-readers of the publication can access the resources that produced the
-published results.
+efficiently by following a number of good \emph{habits}, discussed in
+this section. While there is no firm rule, if you use a container daily,
+is good practice to rebuild that container every once or two weeks. At
+the time of publication of research results it is good practice to save
+a copy of the image in a public data repository so that readers of the
+publication can access the resources that produced the published
+results.
 
-First, use your container every time you work on a project and not just
-as a final step during publication. If the container is the only
-platform you use, the confidence in proper documentation of the
-computing environment can be very high {[}59{]}. You should prioritise
-this usage over others, e.g., non-interactive execution of a full
-workflow, because it gives you personally the highest value and does not
-limit your use or others' use of your data and code at all (see
+First, it is a good habit to use your container every time you work on a
+project and not just as a final step during publication. If the
+container is the only platform you use, the confidence in proper
+documentation of the computing environment can be very high {[}58{]}.
+You should prioritize this usage over others, e.g., non-interactive
+execution of a full workflow, because it gives you personally the
+highest value and does not limit your use or others' use of your data
+and code at all (see
 \hyperref[{rule:interactive}]{Rule~\ztitleref{rule:interactive}}).
 
 Second, for reproducibility, we can treat containers as transient and
@@ -1441,51 +1410,29 @@ disposable, and even intentionally rebuild an image at regular
 intervals. Ideally, containers that we built years ago should rebuild
 seamlessly, but this is not necessarily the case, especially with
 rapidly changing technology relevant to machine learning and data
-science. It can almost be guaranteed future changes will interfere with
-the image build process or even the functionality of the software within
-the image. The longer that you wait to rebuild the image, the more
-change happens, the higher the risk that your build will not work, and
-the harder it becomes to identify and fix the problem. If you are using
-an interactive container and find that you need to manually install a
-package or change a parameter, it is best practice to add this
-dependency to the container and rebuild it right away, but one tends to
-take shortcuts. Therefore, a habitual deletion of a container and
-cache-less rebuild of the image (a) increases security due to updating
-underlying software, (b) helps to reveals issues requiring manual
-interference, i.e., changes to code or configuration not documented in
-the \texttt{Dockerfile} but perhaps should be, and (c) allows you to
-more incrementally debug issues. This habit can be supported by using
-continuous deployment or CI strategies. If a VCS repository with a
-\texttt{Dockerfile} is linked to an automated build, then a CI pipeline
-can build images and execute a validating run the new image, e.g., using
-contained demo data
-(see~\hyperref[{rule:mount}]{Rule~\ztitleref{rule:mount}}).
+science. A habitual deletion of a container and cache-less rebuild of
+the image (a) increases security due to updating underlying software,
+(b) helps to reveals issues requiring manual interference, i.e., changes
+to code or configuration not documented in the \texttt{Dockerfile} but
+perhaps should be, and (c) allows you to more incrementally debug
+issues. This habit can be supported by using continuous deployment or CI
+strategies.
 
 In the case of needing setup or configuration for the first two habits,
 it is good practice to provide a \texttt{Makefile} alongside your
-container, which can capture the specific commands. The effective use of
-a \texttt{Makefile} can help avoiding undocumented steps or manual,
-extra commands to be run on the local machine. A fully scripted
-configuration makes it easier for both you and future users, and can
-increase trust in your workflow. If you use a \texttt{Makefile},
-consider pointing to it instead of adding usage instructions in a
-comment at the end of the \texttt{Dockerfile}. A \texttt{Makefile} will
-also help you to take advantage of build-time variables in a useful way
-(unlike \hyperref[{rule:favour}]{Rule~\ztitleref{rule:favour}}) for
-inserting specific metadata into an image, e.g., the current VCS
-\href{}{commit hash} or a timestamp.
+container, which can capture the specific commands.
 
 Third, from time to time you can reduce the system resources occupied by
 Docker images and their layers or unused containers, volumes and
 networks by running \texttt{docker\ system\ prune\ -\/-all}. After a
 prune is performed, it follows naturally to rebuild a container for
 local usage, or to pull it again from a newly built registry image. This
-habit can be automated with a cron job {[}60{]}.
+habit can be automated with a cron job {[}59{]}.
 
 Fourth, you can export the image to file and deposit it in a public data
 repository, where it not only becomes citable but also provides a
 snapshot of the \emph{actual} environment you used at a specific point
-in time. You should include instructions how to import and run the
+in time. You should include instructions for how to import and run the
 workflow based on the image archive and add your own image tags for
 clarity. Depositing the image next to other project files, i.e., data,
 code, and the used \texttt{Dockerfile}, in a public repository makes
@@ -1493,22 +1440,11 @@ them likely to be preserved, but is is highly unlikely that over time
 you will be able to recreate it precisely from the accompanying
 \texttt{Dockerfile}. Publishing the image and the contained metadata
 therein (e.g., the Docker version used) may even allow future science
-historians to emulate the Docker runtime environment. Applying proper
-preservation strategies (cf.~{[}55{]}) can be highly complex, but simply
-running an image ``as-is'', i.e.~with the default command and entrypoint
-(see \hyperref[{rule:interactive}]{Rule~\ztitleref{rule:interactive}}),
-and observing the output is quite likely to work for many years into the
-future. If the image does not work anymore, a user can still extract the
-image contents and explore the files of each layer manually, or if an
-import still works, with exploration tools like dive {[}36{]}. However,
-if you want to ensure usability and extendability, then you could run
-import, run, and export an image regularly to make sure the export
-format still works with the then current version of Docker.
-
-The exported image and a version controlled \texttt{Dockerfile} together
-allow you to freely experiment and continue development of your workflow
-and keeping the image up to date, e.g., updating versions of pinned
-dependencies (see
+historians to emulate the Docker runtime environment. Sharing the actual
+image via a registry and a version controlled \texttt{Dockerfile}
+together allow you to freely experiment and continue development of your
+workflow and keeping the image up to date, e.g., updating versions of
+pinned dependencies (see
 \hyperref[{rule:pinning}]{Rule~\ztitleref{rule:pinning}}) and regular
 image building (see above).
 
@@ -1520,7 +1456,7 @@ container on a machine of their own. You can do this shortly before
 submitting your reproducible workflow for peer-review, so you are well
 positioned for the future of scholarly communication and open science
 where these may be standard practices required for publication
-{[}19,61--63{]}.
+{[}18,60--62{]}.
 
 \hypertarget{example-dockerfiles}{%
 \section{Example Dockerfiles}\label{example-dockerfiles}}
@@ -1535,28 +1471,24 @@ took from public repositories and updated to adhere better to the rules
 \section*{Conclusion}\label{conclusion}}
 \addcontentsline{toc}{section}{Conclusion}
 
-Reproducibility in research is an endeavor of incremental improvement
-and best efforts, not about achieving the perfect solution, which may be
-not achievable for many researchers with limited resources, and the
-definition of which may change over time. Containerisation can support
-researchers. Containers can be optimised for very different use cases,
-such as supporting many hosts, being small in size for quick deployments
-in cloud infrastructures, but in this article we have provided guidance
-for using \texttt{Dockerfile}s to create containers for use and
-communication in computational research. Our goal is to help the
-researcher to work towards creating a ``time capsule'' {[}64{]} in form
-of a research compendium. Given some expertise and the right tools, such
-a compendium can come as close as needed to the original workflow with
-reasonably little effort for better science. Even if such a capsule
-decays over time, the effort to create and document it provides
+In this article we have provided guidance for using \texttt{Dockerfile}s
+to create containers for use and communication in smaller scaled data
+science research. Reproducibility in research is an endeavor of
+incremental improvement and best efforts, not about achieving the
+perfect solution, which may be not achievable for many researchers with
+limited resources, and the definition of which may change over time.
+Containers can support researchers, and can be optimized for very
+different use cases, such as supporting many hosts, or being small in
+size for quick deployments in cloud infrastructures. Even if imperfect,
+the effort to create and document scientific workflows provides
 incredibly useful and valuable transparency for the project. We
 encourage researchers to value these steps taken by their peers to use
-\texttt{Dockerfile}s to create ``time capsules'', and promote change in
-the way scholars communicate towards an open and friendly
-``preproducibility'' {[}65{]}. So please, make a best effort with your
+\texttt{Dockerfile}s to practice reproducible research, and promote
+change in the way scholars communicate towards an open and friendly
+``preproducibility'' {[}63{]}. So please, make a best effort with your
 current knowledge, and strive to write readable \texttt{Dockerfile}s for
-functional containers, that are realistic about what might break and
-what is unlikely to break. In a similar vein, we accept that you should
+functional containers that are realistic about what might break and what
+is unlikely to break. In a similar vein, we accept that you should
 freely break these rules if another way makes more sense \emph{for your
 use case}. Most importantly, share and exchange your \texttt{Dockerfile}
 freely and collaborate in your community to spread the knowledge about
@@ -1628,299 +1560,287 @@ doi:\href{https://doi.org/10.1371/journal.pcbi.1007007}{10.1371/journal.pcbi.100
 Reproducible Computational Research. PLoS Comput Biol. 2013;9: e1003285.
 doi:\href{https://doi.org/10.1371/journal.pcbi.1003285}{10.1371/journal.pcbi.1003285}
 
-\leavevmode\hypertarget{ref-katz_software_2018}{}%
-7. Katz DS, Chue Hong NP. Software Citation in Theory and Practice. In:
-Davenport JH, Kauers M, Labahn G, Urban J, editors. Mathematical
-Software -- ICMS 2018. Springer International Publishing; 2018. pp.
-289--296.
-doi:\href{https://doi.org/10.1007/978-3-319-96418-8_34}{10.1007/978-3-319-96418-8\_34}
-
 \leavevmode\hypertarget{ref-nust_author_2017}{}%
-8. Nüst D. Author Carpentry : Docker for reproducible research
+7. Nüst D. Author Carpentry : Docker for reproducible research
 {[}Internet{]}. Author Carpentry : Docker for reproducible research.
 2017. Available:
 \url{https://nuest.github.io/docker-reproducible-research/}
 
 \leavevmode\hypertarget{ref-chapman_reproducible_2018}{}%
-9. Chapman P. Reproducible data science environments with Docker Phil
+8. Chapman P. Reproducible data science environments with Docker Phil
 Chapman's Blog {[}Internet{]}. 2018. Available:
 \url{https://chapmandu2.github.io/post/2018/05/26/reproducible-data-science-environments-with-docker/}
 
 \leavevmode\hypertarget{ref-ropensci_labs_r_2015}{}%
-10. rOpenSci Labs. R Docker tutorial {[}Internet{]}. 2015. Available:
+9. rOpenSci Labs. R Docker tutorial {[}Internet{]}. 2015. Available:
 \url{https://ropenscilabs.github.io/r-docker-tutorial/}
 
 \leavevmode\hypertarget{ref-udemy_docker_2019}{}%
-11. Udemy, Zhbanko V. Docker Containers for Data Science and
+10. Udemy, Zhbanko V. Docker Containers for Data Science and
 Reproducible Research {[}Internet{]}. Udemy. 2019. Available:
 \url{https://www.udemy.com/course/docker-containers-data-science-reproducible-research/}
 
 \leavevmode\hypertarget{ref-psomopoulos_lesson_2017}{}%
-12. Psomopoulos FE. Lesson "Docker and Reproducibility" in Workshop
+11. Psomopoulos FE. Lesson "Docker and Reproducibility" in Workshop
 "Reproducible analysis and Research Transparency" {[}Internet{]}.
 Reproducible analysis and Research Transparency. 2017. Available:
 \url{https://reproducible-analysis-workshop.readthedocs.io/en/latest/8.Intro-Docker.html}
 
 \leavevmode\hypertarget{ref-docker_inc_best_2020}{}%
-13. Docker Inc. Best practices for writing Dockerfiles {[}Internet{]}.
+12. Docker Inc. Best practices for writing Dockerfiles {[}Internet{]}.
 Docker Documentation. 2020. Available:
 \url{https://docs.docker.com/develop/develop-images/dockerfile_best-practices/}
 
 \leavevmode\hypertarget{ref-docker-compose_2019}{}%
-14. Docker Inc. Overview of Docker Compose {[}Internet{]}. Docker
+13. Docker Inc. Overview of Docker Compose {[}Internet{]}. Docker
 Documentation. 2019. Available: \url{https://docs.docker.com/compose/}
 
 \leavevmode\hypertarget{ref-nust_opening_2017}{}%
-15. Nüst D, Konkol M, Pebesma E, Kray C, Schutzeichel M, Przibytzin H,
+14. Nüst D, Konkol M, Pebesma E, Kray C, Schutzeichel M, Przibytzin H,
 et al. Opening the Publication Process with Executable Research
 Compendia. D-Lib Magazine. 2017;23.
 doi:\href{https://doi.org/10.1045/january2017-nuest}{10.1045/january2017-nuest}
 
 \leavevmode\hypertarget{ref-cohen_four_2020}{}%
-16. Cohen J, Katz DS, Barker M, Chue Hong NP, Haines R, Jay C. The Four
+15. Cohen J, Katz DS, Barker M, Chue Hong NP, Haines R, Jay C. The Four
 Pillars of Research Software Engineering. IEEE Software. 2020;
 doi:\href{https://doi.org/10.1109/MS.2020.2973362}{10.1109/MS.2020.2973362}
 
 \leavevmode\hypertarget{ref-wikipedia_contributors_docker_2019}{}%
-17. Wikipedia contributors. Docker (software) {[}Internet{]}. Wikipedia.
+16. Wikipedia contributors. Docker (software) {[}Internet{]}. Wikipedia.
 2019. Available:
 \url{https://en.wikipedia.org/w/index.php?title=Docker_(software)\&oldid=928441083}
 
 \leavevmode\hypertarget{ref-boettiger_introduction_2017}{}%
-18. Boettiger C, Eddelbuettel D. An Introduction to Rocker: Docker
+17. Boettiger C, Eddelbuettel D. An Introduction to Rocker: Docker
 Containers for R. The R Journal. 2017;9: 527--536.
 doi:\href{https://doi.org/10.32614/RJ-2017-065}{10.32614/RJ-2017-065}
 
 \leavevmode\hypertarget{ref-chen_open_2019}{}%
-19. Chen X, Dallmeier-Tiessen S, Dasler R, Feger S, Fokianos P, Gonzalez
+18. Chen X, Dallmeier-Tiessen S, Dasler R, Feger S, Fokianos P, Gonzalez
 JB, et al. Open is not enough. Nature Physics. 2019;15: 113.
 doi:\href{https://doi.org/10.1038/s41567-018-0342-2}{10.1038/s41567-018-0342-2}
 
 \leavevmode\hypertarget{ref-brinckman_computing_2018}{}%
-20. Brinckman A, Chard K, Gaffney N, Hategan M, Jones MB, Kowalik K, et
+19. Brinckman A, Chard K, Gaffney N, Hategan M, Jones MB, Kowalik K, et
 al. Computing environments for reproducibility: Capturing the ``Whole
 Tale''. Future Generation Computer Systems. 2018;
 doi:\href{https://doi.org/10.1016/j.future.2017.12.029}{10.1016/j.future.2017.12.029}
 
 \leavevmode\hypertarget{ref-code_ocean_2019}{}%
-21. Code Ocean {[}Internet{]}. 2019. Available:
+20. Code Ocean {[}Internet{]}. 2019. Available:
 \url{https://codeocean.com/}
 
 \leavevmode\hypertarget{ref-simko_reana_2019}{}%
-22. Šimko T, Heinrich L, Hirvonsalo H, Kousidis D, Rodríguez D. REANA: A
+21. Šimko T, Heinrich L, Hirvonsalo H, Kousidis D, Rodríguez D. REANA: A
 System for Reusable Research Data Analyses. EPJ Web of Conferences.
 2019;214: 06034.
 doi:\href{https://doi.org/10.1051/epjconf/201921406034}{10.1051/epjconf/201921406034}
 
 \leavevmode\hypertarget{ref-jupyter_binder_2018}{}%
-23. Jupyter P, Bussonnier M, Forde J, Freeman J, Granger B, Head T, et
+22. Jupyter P, Bussonnier M, Forde J, Freeman J, Granger B, Head T, et
 al. Binder 2.0 - Reproducible, interactive, sharable environments for
 science at scale. Proceedings of the 17th Python in Science Conference.
 2018; 113--120.
 doi:\href{https://doi.org/10.25080/Majora-4af1f417-011}{10.25080/Majora-4af1f417-011}
 
 \leavevmode\hypertarget{ref-docker_inc_dockerfile_2019}{}%
-24. Docker Inc. Dockerfile reference {[}Internet{]}. Docker
+23. Docker Inc. Dockerfile reference {[}Internet{]}. Docker
 Documentation. 2019. Available:
 \url{https://docs.docker.com/engine/reference/builder/}
 
 \leavevmode\hypertarget{ref-wikipedia_contributors_make_2019}{}%
-25. Wikipedia contributors. Make (software) {[}Internet{]}. Wikipedia.
+24. Wikipedia contributors. Make (software) {[}Internet{]}. Wikipedia.
 2019. Available:
 \url{https://en.wikipedia.org/w/index.php?title=Make_(software)\&oldid=929976465}
 
 \leavevmode\hypertarget{ref-kurtzer_singularity_2017}{}%
-26. Kurtzer GM, Sochat V, Bauer MW. Singularity: Scientific containers
+25. Kurtzer GM, Sochat V, Bauer MW. Singularity: Scientific containers
 for mobility of compute. PLOS ONE. 2017;12: e0177459.
 doi:\href{https://doi.org/10.1371/journal.pone.0177459}{10.1371/journal.pone.0177459}
 
 \leavevmode\hypertarget{ref-boettiger_introduction_2015}{}%
-27. Boettiger C. An Introduction to Docker for Reproducible Research.
+26. Boettiger C. An Introduction to Docker for Reproducible Research.
 SIGOPS Oper Syst Rev. 2015;49: 71--79.
 doi:\href{https://doi.org/10.1145/2723872.2723882}{10.1145/2723872.2723882}
 
 \leavevmode\hypertarget{ref-marwick_madjebebe_2015}{}%
-28. Ben Marwick. 1989-excavation-report-Madjebebe. 2015;
+27. Ben Marwick. 1989-excavation-report-Madjebebe. 2015;
 doi:\href{https://doi.org/10.6084/m9.figshare.1297059}{10.6084/m9.figshare.1297059}
 
 \leavevmode\hypertarget{ref-docker_inc_official_2019}{}%
-29. Docker Inc. Official Images on Docker Hub {[}Internet{]}. Docker
+28. Docker Inc. Official Images on Docker Hub {[}Internet{]}. Docker
 Documentation. 2019. Available:
 \url{https://docs.docker.com/docker-hub/official_images/}
 
 \leavevmode\hypertarget{ref-nust_containerit_2019}{}%
-30. Nüst D, Hinz M. Containerit: Generating Dockerfiles for reproducible
+29. Nüst D, Hinz M. Containerit: Generating Dockerfiles for reproducible
 research with R. Journal of Open Source Software. 2019;4: 1603.
 doi:\href{https://doi.org/10.21105/joss.01603}{10.21105/joss.01603}
 
 \leavevmode\hypertarget{ref-stencila_dockta_2019}{}%
-31. Stencila. Stencila/dockta {[}Internet{]}. Stencila; 2019. Available:
+30. Stencila. Stencila/dockta {[}Internet{]}. Stencila; 2019. Available:
 \url{https://github.com/stencila/dockta}
 
 \leavevmode\hypertarget{ref-docker_inc_official_2020}{}%
-32. Docker Inc. Official Images on Docker Hub {[}Internet{]}. Docker
+31. Docker Inc. Official Images on Docker Hub {[}Internet{]}. Docker
 Documentation. 2020. Available:
 \url{https://docs.docker.com/docker-hub/official_images/}
 
 \leavevmode\hypertarget{ref-preston-werner_semantic_2013}{}%
-33. Preston-Werner T. Semantic Versioning 2.0.0 {[}Internet{]}. Semantic
+32. Preston-Werner T. Semantic Versioning 2.0.0 {[}Internet{]}. Semantic
 Versioning. 2013. Available: \url{https://semver.org/}
 
 \leavevmode\hypertarget{ref-halchenko_open_2012}{}%
-34. Halchenko YO, Hanke M. Open is Not Enough. Let's Take the Next Step:
+33. Halchenko YO, Hanke M. Open is Not Enough. Let's Take the Next Step:
 An Integrated, Community-Driven Computing Platform for Neuroscience.
 Frontiers in Neuroinformatics. 2012;6.
 doi:\href{https://doi.org/10.3389/fninf.2012.00022}{10.3389/fninf.2012.00022}
 
 \leavevmode\hypertarget{ref-Wickham2019}{}%
-35. Wickham H, Averick M, Bryan J, Chang W, McGowan L, François R, et
+34. Wickham H, Averick M, Bryan J, Chang W, McGowan L, François R, et
 al. Welcome to the tidyverse. Journal of Open Source Software. The Open
 Journal; 2019;4: 1686.
 doi:\href{https://doi.org/10.21105/joss.01686}{10.21105/joss.01686}
 
 \leavevmode\hypertarget{ref-goodman_dive_2019}{}%
-36. Goodman A. Wagoodman/dive {[}Internet{]}. 2019. Available:
+35. Goodman A. Wagoodman/dive {[}Internet{]}. 2019. Available:
 \url{https://github.com/wagoodman/dive}
 
 \leavevmode\hypertarget{ref-opencontainers_image-spec_2017}{}%
-37. Opencontainers. Opencontainers/image-spec v1.0.1 - Annotations
+36. Opencontainers. Opencontainers/image-spec v1.0.1 - Annotations
 {[}Internet{]}. GitHub. 2017. Available:
 \url{https://github.com/opencontainers/image-spec/blob/v1.0.1/annotations.md}
 
 \leavevmode\hypertarget{ref-the_python_software_foundation_requirements_2019}{}%
-38. The Python Software Foundation. Requirements Files --- pip User
+37. The Python Software Foundation. Requirements Files --- pip User
 Guide {[}Internet{]}. 2019. Available:
 \url{https://pip.pypa.io/en/stable/user_guide/\#requirements-files}
 
 \leavevmode\hypertarget{ref-continuum_analytics_managing_2017}{}%
-39. Continuum Analytics. Managing environments --- conda documentation
+38. Continuum Analytics. Managing environments --- conda documentation
 {[}Internet{]}. 2017. Available:
 \url{https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html}
 
 \leavevmode\hypertarget{ref-r_core_team_description_1999}{}%
-40. R Core Team. The DESCRIPTION file in "writing r extensions"
+39. R Core Team. The DESCRIPTION file in "writing r extensions"
 {[}Internet{]}. 1999. Available:
 \url{https://cran.r-project.org/doc/manuals/r-release/R-exts.html\#The-DESCRIPTION-file}
 
 \leavevmode\hypertarget{ref-eddelbuettel_littler_2019}{}%
-41. Eddelbuettel D, Horner J. Littler: R at the command-line via 'r'
+40. Eddelbuettel D, Horner J. Littler: R at the command-line via 'r'
 {[}Internet{]}. 2019. Available:
 \url{https://CRAN.R-project.org/package=littler}
 
 \leavevmode\hypertarget{ref-npm_creating_2019}{}%
-42. npm. Creating a package.json file npm Documentation {[}Internet{]}.
+41. npm. Creating a package.json file npm Documentation {[}Internet{]}.
 2019. Available:
 \url{https://docs.npmjs.com/creating-a-package-json-file}
 
 \leavevmode\hypertarget{ref-julia_tomls_2019}{}%
-43. The Julia Language Contributors. 10. Project.Toml and Manifest.Toml
+42. The Julia Language Contributors. 10. Project.Toml and Manifest.Toml
 · Pkg.Jl {[}Internet{]}. 2019. Available:
 \url{https://julialang.github.io/Pkg.jl/v1/toml-files/}
 
 \leavevmode\hypertarget{ref-docker_use_2019}{}%
-44. Docker Inc. Use bind mounts {[}Internet{]}. Docker Documentation.
+43. Docker Inc. Use bind mounts {[}Internet{]}. Docker Documentation.
 2019. Available: \url{https://docs.docker.com/storage/bind-mounts/}
 
 \leavevmode\hypertarget{ref-verstegen_pluc_mozambique_2019}{}%
-45. Verstegen JA. JudithVerstegen/PLUC\_Mozambique: First release of
+44. Verstegen JA. JudithVerstegen/PLUC\_Mozambique: First release of
 PLUC for Mozambique {[}Internet{]}. Zenodo; 2019.
 doi:\href{https://doi.org/10.5281/zenodo.3519987}{10.5281/zenodo.3519987}
 
 \leavevmode\hypertarget{ref-sochat_scientific_2018}{}%
-46. Sochat V. The Scientific Filesystem. GigaScience. 2018;7.
+45. Sochat V. The Scientific Filesystem. GigaScience. 2018;7.
 doi:\href{https://doi.org/10.1093/gigascience/giy023}{10.1093/gigascience/giy023}
 
 \leavevmode\hypertarget{ref-knoth_reproducibility_2017}{}%
-47. Knoth C, Nüst D. Reproducibility and Practical Adoption of GEOBIA
+46. Knoth C, Nüst D. Reproducibility and Practical Adoption of GEOBIA
 with Open-Source Software in Docker Containers. Remote Sensing. 2017;9:
 290. doi:\href{https://doi.org/10.3390/rs9030290}{10.3390/rs9030290}
 
 \leavevmode\hypertarget{ref-molenaar_klikoscientific_2018}{}%
-48. Molenaar G, Makhathini S, Girard JN, Smirnov O. Kliko---The
+47. Molenaar G, Makhathini S, Girard JN, Smirnov O. Kliko---The
 scientific compute container format. Astronomy and Computing. 2018;25:
 1--9.
 doi:\href{https://doi.org/10.1016/j.ascom.2018.08.003}{10.1016/j.ascom.2018.08.003}
 
 \leavevmode\hypertarget{ref-docker_kitematic_2019}{}%
-49. Docker Inc. Docker/kitematic {[}Internet{]}. Docker; 2019.
+48. Docker Inc. Docker/kitematic {[}Internet{]}. Docker; 2019.
 Available: \url{https://github.com/docker/kitematic}
 
 \leavevmode\hypertarget{ref-selenium_2019}{}%
-50. Selenium contributors. SeleniumHQ/selenium {[}Internet{]}. Selenium;
+49. Selenium contributors. SeleniumHQ/selenium {[}Internet{]}. Selenium;
 2019. Available: \url{https://github.com/SeleniumHQ/selenium}
 
 \leavevmode\hypertarget{ref-singularity_frequently_2019}{}%
-51. Singularity. Frequently Asked Questions Singularity {[}Internet{]}.
+50. Singularity. Frequently Asked Questions Singularity {[}Internet{]}.
 2019. Available:
 \url{http://singularity.lbl.gov/archive/docs/v2-2/faq\#can-i-run-x11-apps-through-singularity}
 
 \leavevmode\hypertarget{ref-viereck_x11docker_2019}{}%
-52. Viereck M. X11docker: Run GUI applications in Docker containers.
+51. Viereck M. X11docker: Run GUI applications in Docker containers.
 Journal of Open Source Software. 2019;4: 1349.
 doi:\href{https://doi.org/10.21105/joss.01349}{10.21105/joss.01349}
 
 \leavevmode\hypertarget{ref-yaremenko_docker-x11-bridge_2019}{}%
-53. Yaremenko E. JAremko/docker-x11-bridge {[}Internet{]}. 2019.
+52. Yaremenko E. JAremko/docker-x11-bridge {[}Internet{]}. 2019.
 Available: \url{https://github.com/JAremko/docker-x11-bridge}
 
 \leavevmode\hypertarget{ref-yuvipanda_jupyter-desktop-server_2019}{}%
-54. Panda Y. Yuvipanda/jupyter-desktop-server {[}Internet{]}. 2019.
+53. Panda Y. Yuvipanda/jupyter-desktop-server {[}Internet{]}. 2019.
 Available: \url{https://github.com/yuvipanda/jupyter-desktop-server}
 
 \leavevmode\hypertarget{ref-emsley_framework_2018}{}%
-55. Emsley I, De Roure D. A Framework for the Preservation of a Docker
+54. Emsley I, De Roure D. A Framework for the Preservation of a Docker
 Container International Journal of Digital Curation. International
 Journal of Digital Curation. 2018;12.
 doi:\href{https://doi.org/10.2218/ijdc.v12i2.509}{10.2218/ijdc.v12i2.509}
 
 \leavevmode\hypertarget{ref-kim_bio-docklets_2017}{}%
-56. Kim B, Ali TA, Lijeron C, Afgan E, Krampis K. Bio-Docklets:
+55. Kim B, Ali TA, Lijeron C, Afgan E, Krampis K. Bio-Docklets:
 Virtualization Containers for Single-Step Execution of NGS Pipelines.
 bioRxiv. 2017; 116962.
 doi:\href{https://doi.org/10.1101/116962}{10.1101/116962}
 
 \leavevmode\hypertarget{ref-cookiecutter_contributors_cookiecutter_2019}{}%
-57. \{Cookiecutter contributors\}. Cookiecutter/cookiecutter
+56. \{Cookiecutter contributors\}. Cookiecutter/cookiecutter
 {[}Internet{]}. cookiecutter; 2019. Available:
 \url{https://github.com/cookiecutter/cookiecutter}
 
 \leavevmode\hypertarget{ref-marwick_rrtools_2019}{}%
-58. Marwick B. Benmarwick/rrtools {[}Internet{]}. 2019. Available:
+57. Marwick B. Benmarwick/rrtools {[}Internet{]}. 2019. Available:
 \url{https://github.com/benmarwick/rrtools}
 
 \leavevmode\hypertarget{ref-marwick_readme_2015}{}%
-59. Marwick B. README of 1989-excavation-report-Madjebebe. 2015;
+58. Marwick B. README of 1989-excavation-report-Madjebebe. 2015;
 doi:\href{https://doi.org/10.6084/m9.figshare.1297059}{10.6084/m9.figshare.1297059}
 
 \leavevmode\hypertarget{ref-wikipedia_contributors_cron_2019}{}%
-60. Wikipedia contributors. Cron {[}Internet{]}. Wikipedia. 2019.
+59. Wikipedia contributors. Cron {[}Internet{]}. Wikipedia. 2019.
 Available:
 \url{https://en.wikipedia.org/w/index.php?title=Cron\&oldid=929379536}
 
 \leavevmode\hypertarget{ref-eglen_codecheck_2019}{}%
-61. Eglen S, Nüst D. CODECHECK: An open-science initiative to facilitate
+60. Eglen S, Nüst D. CODECHECK: An open-science initiative to facilitate
 sharing of computer programs and results presented in scientific
 publications. Septentrio Conference Series. 2019;
 doi:\href{https://doi.org/10.7557/5.4910}{10.7557/5.4910}
 
 \leavevmode\hypertarget{ref-schonbrodt_training_2019}{}%
-62. Schönbrodt F. Training students for the Open Science future. Nature
+61. Schönbrodt F. Training students for the Open Science future. Nature
 Human Behaviour. 2019;3: 1031--1031.
 doi:\href{https://doi.org/10.1038/s41562-019-0726-z}{10.1038/s41562-019-0726-z}
 
 \leavevmode\hypertarget{ref-eglen_recent_2018}{}%
-63. Eglen SJ, Mounce R, Gatto L, Currie AM, Nobis Y. Recent developments
+62. Eglen SJ, Mounce R, Gatto L, Currie AM, Nobis Y. Recent developments
 in scholarly publishing to improve research practices in the life
 sciences. Emerging Topics in Life Sciences. 2018;2: 775--778.
 doi:\href{https://doi.org/10.1042/ETLS20180172}{10.1042/ETLS20180172}
 
-\leavevmode\hypertarget{ref-blank_twitter_2019}{}%
-64. Blank D, Twitter. Twitter thread on reproducibility time capsules on
-Twitter {[}Internet{]}. Twitter. 2019. Available:
-\url{https://twitter.com/dougblank/status/1135904909663068165}
-
 \leavevmode\hypertarget{ref-stark_before_2018}{}%
-65. Stark PB. Before reproducibility must come preproducibility
+63. Stark PB. Before reproducibility must come preproducibility
 {[}Internet{]}. Nature. 2018.
 doi:\href{https://doi.org/10.1038/d41586-018-05256-0}{10.1038/d41586-018-05256-0}
 


### PR DESCRIPTION
This pull request is a first shot at cleaning up the manuscript, namely:

 - the introduction side tracked into talking about research compendiums, which was distracting and out of scope for an introduction that should be focused on leading into talking about building data science containers. 
 - I removed lines that (although possibly true / meaningful) didn't add to the flow of the paper.

I can add comment for any specific choice for reviewers that are interested.

Signed-off-by: vsoch <vsochat@stanford.edu>