### PR TITLE
Embellish introduction

### DIFF
--- a/ten-simple-rules-dockerfiles.Rmd
+++ b/ten-simple-rules-dockerfiles.Rmd
@@ -86,7 +86,7 @@ To start with, we assume you have a scripted scientific workflow, i.e. you can, 
 Since containers that you eventually share with others can only run open source software, tools like Mathematica and Matlab are out of scope for this example.
 A workflow that does not support scripted execution is also out of scope for reproducible research, as it does not fit well with containerization.
 Furthermore, workflows interacting with many petabytes of data and executed in high-performance computing (HPC) infrastructures are out of scope.
-Using such HPC job managers or cloud infrastructures would require a collection of "Ten Simple Rules" articles in their own right, however we would encourage the reader to look at Singularity [@kurtzer_singularity_2017] for this use case.
+Using such HPC job managers or cloud infrastructures would require a collection of "Ten Simple Rules" articles in their own right, however we would encourage the reader to look at `Singularity` [@kurtzer_singularity_2017] for this use case.
 For this article, we focus on workflows that typically run on single machine, e.g., a researchers laptop computer or a virtual server.
 The reader might scope the data requirement to less than a terabyte, and compute requirement to a machine with 16 cores running over the weekend.
 

--- a/ten-simple-rules-dockerfiles.Rmd
+++ b/ten-simple-rules-dockerfiles.Rmd
@@ -86,7 +86,7 @@ To start with, we assume you have a scripted scientific workflow, i.e. you can, 
 Since containers that you eventually share with others can only run open source software, tools like Mathematica and Matlab are out of scope for this example.
 A workflow that does not support scripted execution is also out of scope for reproducible research, as it does not fit well with containerization.
 Furthermore, workflows interacting with many petabytes of data and executed in high-performance computing (HPC) infrastructures are out of scope.
-Using such HPC job managers or cloud infrastructures would require a collection of "Ten Simple Rules" articles in their own right.
+Using such HPC job managers or cloud infrastructures would require a collection of "Ten Simple Rules" articles in their own right, however we would encourage the reader to look at Singularity [@kurtzer_singularity_2017] for this use case.
 For this article, we focus on workflows that typically run on single machine, e.g., a researchers laptop computer or a virtual server.
 The reader might scope the data requirement to less than a terabyte, and compute requirement to a machine with 16 cores running over the weekend.
 

--- a/ten-simple-rules-dockerfiles.Rmd
+++ b/ten-simple-rules-dockerfiles.Rmd
@@ -86,7 +86,8 @@ To start with, we assume you have a scripted scientific workflow, i.e. you can, 
 Since containers that you eventually share with others can only run open source software, tools like Mathematica and Matlab are out of scope for this example.
 A workflow that does not support scripted execution is also out of scope for reproducible research, as it does not fit well with containerization.
 Furthermore, workflows interacting with many petabytes of data and executed in high-performance computing (HPC) infrastructures are out of scope.
-Using such HPC job managers or cloud infrastructures would require a collection of "Ten Simple Rules" articles in their own right, however we would encourage the reader to look at `Singularity` [@kurtzer_singularity_2017] for this use case.
+Using such HPC job managers or cloud infrastructures would require a collection of "Ten Simple Rules" articles in their own right. 
+For the HPC use case, we encourage the reader to look at Singularity [@kurtzer_singularity_2017].
 For this article, we focus on workflows that typically run on single machine, e.g., a researchers laptop computer or a virtual server.
 The reader might scope the data requirement to less than a terabyte, and compute requirement to a machine with 16 cores running over the weekend.
 


### PR DESCRIPTION
Just a few small changes to the introduction. 

A couple of points we might consider addressing in the introduction:

1. Why containers and not VMs e.g. easily version controllable and to an extent self-documenting, less bulk / minimal information to reproduce the environment etc.
2. The rise of containers' popularity and therefore ease of integration in other parts of the ecosystem e.g. their use in CI, development in VS Code, mybinder.org etc.