### PR TITLE
Remove contradictory analogy

### DIFF
--- a/ten-simple-rules-dockerfiles.Rmd
+++ b/ten-simple-rules-dockerfiles.Rmd
@@ -137,7 +137,7 @@ Containers are distinct from virtual machines or hypervisors, as they do not emu
 Several solutions for facilitating reproducible research are built on top of containers [@brinckman_computing_2018; @code_ocean_2019; @simko_reana_2019; @jupyter_binder_2018; @nust_opening_2017], but these solutions intentionally hide most of the complexity from the researcher.
 
 To create Docker containers for specific workflows, we write text files that follow a particular format called `Dockerfile` [@docker_inc_dockerfile_2019].
-A `Dockerfile` is a machine- _and_ human-readable recipe, comparable to a `Makefile` [@wikipedia_contributors_make_2019], for building _images_.
+A `Dockerfile` is a machine- _and_ human-readable recipe for building _images_.
 Here, images are executable files that include the application, e.g., the programming language interpreter needed to run a workflow, and the system libraries required by an application to run.
 Thus, a `Dockerfile` consists of a sequence of instructions to copy files and install software.
 Each instruction adds a layer to the image, which can be cached across image builds for minimizing build and download times.


### PR DESCRIPTION
I propose removing this initial comparison of `Dockerfile`s with Makefiles because:

  1. It is inconsistent with the main analogy (see figure) where a `Dockerfile` is compared to source code
  2. We later recommend including a Makefile in your repository to help remember arguments for commands

As such, this comparison might cause unnecessary confusion. I also think the sentence reads better without this clause. 